### PR TITLE
Update server to read env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and edit the values as needed
+JWT_SECRET=your-secret-here
+DB_PATH=./server/users.db
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# LetuslearnID
+
+This repository contains a lightweight account system built with Node.js and SQLite.
+
+## Getting Started
+
+1. Copy `.env.example` to `.env`:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` and set values for `JWT_SECRET`, `DB_PATH` and `PORT`.
+3. Install dependencies and start the server:
+   ```bash
+   cd server
+   npm install
+   node index.js
+   ```
+
+The default configuration stores the SQLite database in `server/users.db` and listens on port 3000.

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,8 @@ const { promisify } = require('util');
 const app = express();
 app.use(express.json());
 
-const db = new sqlite3.Database(path.join(__dirname, 'users.db'));
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, 'users.db');
+const db = new sqlite3.Database(DB_PATH);
 
 // Initialize user table if it doesn't exist
 const initDb = () => {


### PR DESCRIPTION
## Summary
- make DB path configurable via `DB_PATH`
- document environment variables in a new README
- provide `.env.example` for easy setup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68402fc4ed348326bab63b3f92153d38