### PR TITLE
Add README and DB_PATH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# LetuslearnID
+
+This repository contains a lightweight account management server built with [Express](https://expressjs.com/). It currently stores user data in SQLite to keep resource usage minimal.
+
+## Prerequisites
+
+- **Node.js** 18 or 20
+- **npm** (comes with Node.js)
+- **Optional:** Python 3.11 if `node-gyp` needs to compile native modules
+
+## Setup
+
+Install dependencies by running:
+
+```bash
+cd server && npm install
+```
+
+## Running the Server
+
+Before starting the server you can set the following environment variables:
+
+- `JWT_SECRET` – secret used to sign tokens (default: `dev-secret`)
+- `PORT` – port for the HTTP server (default: `3000`)
+- `DB_PATH` – path to the SQLite database file (default: `./server/users.db`)
+
+Start the API from the `server` directory with:
+
+```bash
+node index.js
+```
+
+## Future Work
+
+The project plans to migrate from SQLite to PostgreSQL in order to scale more efficiently. This migration is tracked as future technical debt.

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,8 @@ const { promisify } = require('util');
 const app = express();
 app.use(express.json());
 
-const db = new sqlite3.Database(path.join(__dirname, 'users.db'));
+const dbPath = process.env.DB_PATH || path.join(__dirname, 'users.db');
+const db = new sqlite3.Database(dbPath);
 
 // Initialize user table if it doesn't exist
 const initDb = () => {


### PR DESCRIPTION
## Summary
- add main `README.md`
- support `DB_PATH` environment variable in server

## Testing
- `npm install` in `server`
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_68402fc0a95c8326afcebeb0a328ca19