### PR TITLE
Add npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Start the API from the `server` directory with:
 ```bash
 node index.js
 ```
+
+Or run the convenience script:
+
+```bash
+npm start
+```
 Once running, visit http://localhost:3000/ to see the web interface.
 
 ## Future Work

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add start script for the server
- document starting with `npm start` as an alternative

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684035f6ead8832698d51b218e594889