### PR TITLE
Align DB_FILE env var docs with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Before starting the server you can set the following environment variables:
 
 - `JWT_SECRET` – secret used to sign tokens (default: `dev-secret`)
 - `PORT` – port for the HTTP server (default: `3000`)
-- `DB_PATH` – path to the SQLite database file (default: `./server/users.db`)
+- `DB_FILE` – path to the SQLite database file (default: `./server/users.db`)
+
+The variable was renamed from `DB_PATH` to `DB_FILE` to better describe its
+purpose. Older scripts using `DB_PATH` should be updated.
 
 Start the API from the `server` directory with:
 


### PR DESCRIPTION
## Summary
- update README to use `DB_FILE`
- note the rename from `DB_PATH`

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_684035f46ed88326bef76f353cc814be