### PR TITLE
实现登录跳转和免登录时长

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ cd server && npm install
 npm start
 ```
 
-服务启动后可访问 [http://localhost:3000/](http://localhost:3000/) 以打开登录页，账户设置页面位于 `/settings/` 目录。
+服务启动后可访问 [http://localhost:3000/](http://localhost:3000/) 以打开登录页。
+登录表单允许设置 2-13 天的免登录时长，成功后跳转到 `/manage/` 管理页面，账户设置页面位于 `/settings/` 目录。
 
 ## 测试
 

--- a/client/index/index.html
+++ b/client/index/index.html
@@ -28,6 +28,7 @@
       const [password, setPassword] = React.useState('');
       const [locale, setLocale] = React.useState('en_us');
       const [t, setT] = React.useState({});
+      const [days, setDays] = React.useState(2);
 
       React.useEffect(() => {
         fetch(`../../i18n/${locale}.json`)
@@ -41,12 +42,12 @@
             const res = await fetch("/login", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ username, password })
+              body: JSON.stringify({ username, password, rememberDays: Number(days) })
             });
             const data = await res.json();
             if (res.ok) {
               localStorage.setItem("token", data.token);
-              alert("Login successful");
+              window.location.href = "../manage/index.html";
             } else {
               alert(data.error || "Login failed");
             }
@@ -80,6 +81,7 @@
           React.createElement('h1', null, t.title),
           React.createElement('input', { type:'text', placeholder:t.username, value:username, onChange:e=>setUsername(e.target.value) }),
           React.createElement('input', { type:'password', placeholder:t.password, value:password, onChange:e=>setPassword(e.target.value) }),
+          React.createElement('input', { type:'number', min:2, max:13, value:days, onChange:e=>setDays(e.target.value) , placeholder:t.remember_days }),
           React.createElement('button', { className:'button', onClick:handleLogin },
             React.createElement('i', { className:'fa-solid fa-right-to-bracket icon-black' }), t.login
           ),

--- a/client/manage/index.html
+++ b/client/manage/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Manage</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <style>
+    body { font-family: Arial, sans-serif; margin:0; padding:40px; background:#f5f5f5; }
+    .container { max-width:400px; margin:0 auto; background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+    h1 { text-align:center; }
+    a { display:block; margin-top:15px; text-align:center; color:#007bff; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+  <script>
+    function ManageApp() {
+      const [locale, setLocale] = React.useState('en_us');
+      const [t, setT] = React.useState({});
+
+      React.useEffect(() => {
+        fetch(`../../i18n/${locale}.json`)
+          .then(res => res.json())
+          .then(setT)
+          .catch(() => setT({}));
+      }, [locale]);
+
+      return (
+        React.createElement('div', { className:'container' },
+          React.createElement('select', { value:locale, onChange:e=>setLocale(e.target.value) },
+            React.createElement('option', { value:'en_us' }, 'English'),
+            React.createElement('option', { value:'zh_cn' }, '\u4e2d\u6587')
+          ),
+          React.createElement('h1', null, t.manage_title),
+          React.createElement('a', { href:'../settings/index.html' }, t.settings_title)
+        )
+      );
+    }
+    ReactDOM.render(React.createElement(ManageApp), document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/i18n/en_us.json
+++ b/i18n/en_us.json
@@ -14,5 +14,7 @@
   "passkeys": "Manage Passkeys",
   "backup_codes": "Generate Backup Codes",
   "save": "Save Settings",
-  "logout": "Logout"
+  "logout": "Logout",
+  "remember_days": "Days to stay logged in",
+  "manage_title": "Management"
 }

--- a/i18n/zh_cn.json
+++ b/i18n/zh_cn.json
@@ -14,5 +14,7 @@
   "passkeys": "管理通行密钥",
   "backup_codes": "生成备用代码",
   "save": "保存设置",
-  "logout": "登出"
+  "logout": "登出",
+  "remember_days": "保持登录天数",
+  "manage_title": "管理页面"
 }

--- a/server/index.js
+++ b/server/index.js
@@ -41,8 +41,9 @@ const createUser = async (username, passwordHash) => {
 // JWT secret; in production use environment variable
 const SECRET = process.env.JWT_SECRET || 'dev-secret';
 
-const generateToken = (user) => {
-  return jwt.sign({ id: user.id, username: user.username }, SECRET, { expiresIn: '1h' });
+const generateToken = (user, days) => {
+  const opts = days && days > 1 && days < 14 ? { expiresIn: `${days}d` } : { expiresIn: '1h' };
+  return jwt.sign({ id: user.id, username: user.username }, SECRET, opts);
 };
 
 const authenticateToken = (req, res, next) => {
@@ -76,7 +77,7 @@ app.post('/register', async (req, res) => {
 });
 
 app.post('/login', async (req, res) => {
-  const { username, password } = req.body;
+  const { username, password, rememberDays } = req.body;
   if (!username || !password) {
     return res.status(400).json({ error: 'Username and password are required' });
   }
@@ -89,7 +90,7 @@ app.post('/login', async (req, res) => {
     if (!match) {
       return res.status(401).json({ error: 'Invalid credentials' });
     }
-    const token = generateToken(user);
+    const token = generateToken(user, rememberDays);
     res.json({ token });
   } catch (err) {
     console.error(err);

--- a/server/test/auth.test.js
+++ b/server/test/auth.test.js
@@ -1,6 +1,7 @@
 process.env.DB_FILE = ':memory:';
 const request = require('supertest');
 const assert = require('assert');
+const jwt = require('jsonwebtoken');
 const { app, initDb, db } = require('../index');
 
 before(async () => {
@@ -29,12 +30,14 @@ describe('POST /register', () => {
 });
 
 describe('POST /login', () => {
-  it('returns a token with valid credentials', async () => {
+  it('returns a token with valid credentials and rememberDays', async () => {
     const res = await request(app)
       .post('/login')
-      .send({ username: 'alice', password: 'secret' });
+      .send({ username: 'alice', password: 'secret', rememberDays: 2 });
     assert.strictEqual(res.status, 200);
     assert.ok(res.body.token);
+    const decoded = jwt.decode(res.body.token);
+    assert.strictEqual(Math.round((decoded.exp - decoded.iat) / 86400), 2);
     global.token = res.body.token;
   });
 

--- a/server/test/e2e.test.js
+++ b/server/test/e2e.test.js
@@ -53,7 +53,7 @@ describe('Browser flows', function() {
       const r = await fetch('/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: u, password: p })
+        body: JSON.stringify({ username: u, password: p, rememberDays: 2 })
       });
       const body = await r.json();
       if (r.ok) localStorage.setItem('token', body.token);


### PR DESCRIPTION
## 摘要
- 增加 `/manage` 管理页面
- 登录页支持设置 2~13 天免登录时长并在登录后跳转管理页面
- JWT 登录接口支持 `rememberDays` 参数
- 更新中英文翻译文件
- 调整单元测试和 e2e 测试
- 更新 README 说明

## 测试指南
在 `server` 目录执行:
```bash
npm install
npm test
```
全部测试应通过。

------
https://chatgpt.com/codex/tasks/task_e_684178905618832685f09b2b452d933a