### PR TITLE
修复设置页兼容性问题

### DIFF
--- a/client/settings/index.html
+++ b/client/settings/index.html
@@ -42,7 +42,7 @@
       const bookmarks = React.useMemo(() => {
         try {
           return JSON.parse(localStorage.getItem('bookmarks') || '[]');
-        } catch { return []; }
+        } catch (e) { return []; }
       }, []);
 
       React.useEffect(() => {


### PR DESCRIPTION
## 摘要
- 修正设置页脚本的 `catch {}` 写法，避免旧浏览器解析错误

## 测试
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_684182fae42c8326a14aea6636e658a3