### PR TITLE
Add TOTP two-factor auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LetuslearnID
 
 LetuslearnID 是一个简单轻量的账户管理服务器，基于 [Express](https://expressjs.com/) 实现。为了减少内存占用，默认使用 SQLite 存储用户数据，同时提供 React 前端页面及多语言支持。
+现在支持 TOTP 双因素认证，生成二维码与 12 个一次性备用代码，启用后登录需输入动态口令或备用代码。
 
 ## 目录结构
 

--- a/client/index/index.html
+++ b/client/index/index.html
@@ -75,9 +75,12 @@
               body: JSON.stringify({ username, password, fingerprint: getFingerprint() })
             });
             const data = await res.json();
-            if (res.ok) {
+            if (res.ok && data.token) {
               localStorage.setItem("token", data.token);
               window.location.href = "../success/index.html?type=login";
+            } else if (data.tfa) {
+              sessionStorage.setItem('tfa', data.temp);
+              window.location.href = '../totp/verify.html';
             } else {
               window.location.href = `../failure/index.html?msg=${encodeURIComponent(data.error || 'Login failed')}`;
             }

--- a/client/settings/index.html
+++ b/client/settings/index.html
@@ -42,6 +42,7 @@
       const [showConfirm, setShowConfirm] = React.useState(false);
       const [sessionDays, setSessionDays] = React.useState(2);
       const [twoFactor, setTwoFactor] = React.useState(false);
+      const [origTwoFactor, setOrigTwoFactor] = React.useState(false);
       const [passkey, setPasskey] = React.useState(false);
       const [username, setUsername] = React.useState('');
       const [menuOpen, setMenuOpen] = React.useState(false);
@@ -56,7 +57,7 @@
         if (token) {
           fetch('/profile', { headers: { 'Authorization': 'Bearer ' + token } })
             .then(res => res.json())
-            .then(data => setUsername(data.username || ''))
+            .then(data => { setUsername(data.username || ''); setTwoFactor(!!data.totp); setOrigTwoFactor(!!data.totp); })
             .catch(() => {});
         }
       }, []);
@@ -77,6 +78,13 @@
             headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
             body: JSON.stringify({ fingerprint: getFingerprint(), days: Number(sessionDays) })
           });
+          if (twoFactor && !origTwoFactor) {
+            const res = await fetch('/totp/setup', { method:'POST', headers:{ 'Authorization':'Bearer '+token } });
+            const data = await res.json();
+            sessionStorage.setItem('totpSetup', JSON.stringify(data));
+            window.location.href = '../totp/setup.html';
+            return;
+          }
           if (passkey) {
             const optRes = await fetch('/passkey/options', { method:'POST', headers:{ 'Authorization':'Bearer '+token } });
             const opts = await optRes.json();
@@ -124,8 +132,14 @@
         }
       };
 
-      const handleBackupCodes = () => {
-        window.location.href = '../success/index.html?msg=' + encodeURIComponent('Generate backup codes') + '&next=../settings/index.html';
+      const handleBackupCodes = async () => {
+        const token = localStorage.getItem('token');
+        const res = await fetch('/totp/regenerate', { method:'POST', headers:{ 'Authorization':'Bearer '+token } });
+        if(res.ok){
+          const data = await res.json();
+          sessionStorage.setItem('totpCodes', JSON.stringify(data.codes));
+          window.location.href = '../totp/backup.html';
+        }
       };
 
       const handleLogout = async () => {

--- a/client/totp/backup.html
+++ b/client/totp/backup.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Backup Codes</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;align-items:center;justify-content:center;height:100vh;animation:fadeIn .3s ease;}
+    .box{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);text-align:center;width:360px;}
+    ul{list-style:none;padding:0;}
+    li{background:#eee;margin:4px 0;padding:4px;border-radius:4px;}
+    .button{width:100%;padding:10px;background:#000;color:#fff;border:none;border-radius:20px;cursor:pointer;margin-top:10px;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+  </style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+<script>
+function Codes(){
+  const codes=JSON.parse(sessionStorage.getItem('totpCodes')||'[]');
+  const download=()=>{
+    const blob=new Blob([codes.join('\n')],{type:'text/markdown'});
+    const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='backup_codes.md';a.click();
+  };
+  return React.createElement('div',{className:'box'},[
+    React.createElement('ul',{key:0},codes.map((c,i)=>React.createElement('li',{key:i},c))),
+    React.createElement('button',{key:1,className:'button',onClick:download},'下载')
+  ]);
+}
+ReactDOM.render(React.createElement(Codes),document.getElementById('root'));
+</script>
+</body>
+</html>

--- a/client/totp/setup.html
+++ b/client/totp/setup.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>TOTP Setup</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;align-items:center;justify-content:center;height:100vh;animation:fadeIn .3s ease;}
+    .box{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);text-align:center;width:360px;}
+    .gray{color:#666;font-size:0.9em;cursor:pointer;}
+    pre{background:#eee;padding:10px;border-radius:4px;white-space:pre-wrap;word-break:break-all;}
+    ul{list-style:none;padding:0;}
+    li{background:#eee;margin:4px 0;padding:4px;border-radius:4px;}
+    .button{width:100%;padding:10px;background:#000;color:#fff;border:none;border-radius:20px;cursor:pointer;margin-top:10px;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+  </style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+<script>
+function Setup(){
+  const data = JSON.parse(sessionStorage.getItem('totpSetup')||'{}');
+  const [show, setShow] = React.useState(false);
+  const download = () => {
+    const blob = new Blob([data.codes.join('\n')], {type:'text/markdown'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'backup_codes.md';
+    a.click();
+  };
+  return React.createElement('div',{className:'box'},[
+    React.createElement('img',{key:0,src:'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data='+encodeURIComponent(data.url)}),
+    React.createElement('div',{key:1,className:'gray',onClick:()=>setShow(!show)},'无法使用？复制代码。'),
+    show && React.createElement('pre',{key:2},data.secret),
+    React.createElement('p',{key:3},'请使用双因子认证器扫描下方二维码\n如「Google Authenticator」「1Password」等'),
+    React.createElement('ul',{key:4},data.codes.map((c,i)=>React.createElement('li',{key:i},c))),
+    React.createElement('button',{key:5,className:'button',onClick:download},'下载备份代码')
+  ]);
+}
+ReactDOM.render(React.createElement(Setup),document.getElementById('root'));
+</script>
+</body>
+</html>

--- a/client/totp/verify.html
+++ b/client/totp/verify.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>TOTP Verify</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;align-items:center;justify-content:center;height:100vh;animation:fadeIn .3s ease;}
+    .box{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);text-align:center;width:360px;}
+    input{width:100%;padding:10px;margin:8px 0;border:1px solid #ccc;border-radius:4px;}
+    .gray{color:#666;font-size:0.9em;cursor:pointer;margin-bottom:10px;}
+    .button{width:100%;padding:10px;background:#000;color:#fff;border:none;border-radius:20px;cursor:pointer;margin-top:10px;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+  </style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+<script>
+function Verify(){
+  const [code,setCode]=React.useState('');
+  const [useBackup,setUseBackup]=React.useState(false);
+  const submit=async()=>{
+    const token=sessionStorage.getItem('tfa');
+    const res=await fetch('/totp/verify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token,code})});
+    const data=await res.json();
+    if(res.ok){localStorage.setItem('token',data.token);window.location.href='../manage/index.html';}else{window.location.href='../failure/index.html?msg='+encodeURIComponent(data.error||'Verify failed');}
+  };
+  return React.createElement('div',{className:'box'},[
+    React.createElement('input',{key:0,placeholder:'TOTP',value:code,onChange:e=>setCode(e.target.value)}),
+    React.createElement('div',{key:1,className:'gray',onClick:()=>setUseBackup(!useBackup)},'无法访问？使用备份代码。'),
+    React.createElement('button',{key:2,className:'button',onClick:submit},'提交')
+  ]);
+}
+ReactDOM.render(React.createElement(Verify),document.getElementById('root'));
+</script>
+</body>
+</html>

--- a/docs/dev/userdataTable.md
+++ b/docs/dev/userdataTable.md
@@ -8,12 +8,11 @@ The following table describes a simple relational schema for storing user accoun
 | `username`          | VARCHAR       | Login name, unique                               |
 | `password_hash`     | VARCHAR       | Hash of user password                            |
 | `email`             | VARCHAR       | User email address                               |
-| `two_factor_enabled`| BOOLEAN       | Whether two‑factor authentication is enabled     |
-| `two_factor_secret` | VARCHAR       | Secret or seed used for TOTP / authenticator app |
+| `totp_secret`       | VARCHAR       | Secret used for TOTP authenticator apps |
+| `backup_codes`      | TEXT          | JSON array of one‑time backup codes |
 | `credential_id`     | TEXT          | Credential ID of registered passkey |
 | `passkey_public`    | TEXT          | Public key data for passkeys (WebAuthn) |
 | `counter`           | INTEGER       | WebAuthn signature counter |
-| `backup_codes`      | TEXT          | Comma separated one‑time backup codes            |
 | `created_at`        | DATETIME      | Record creation time                             |
 | `updated_at`        | DATETIME      | Last update time                                 |
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "bcryptjs": "^3.0.2",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
+        "otplib": "^12.0.1",
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
@@ -78,6 +79,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -2396,6 +2444,17 @@
         "wrappy": "1"
       }
     },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3247,6 +3306,14 @@
       "license": "ISC",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/to-regex-range": {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "bcryptjs": "^3.0.2",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
+    "otplib": "^12.0.1",
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- implement TOTP 2FA on server and client
- update user table docs
- add setup/verify pages and backup codes handling
- adjust tests for the new flow

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6842c0bb9fcc83269413ae7fbe13ab14