### PR TITLE
新增 TOTP 备份码测试

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ npm start
 npm test    # 包含单元以及 e2e 测试
 ```
 
+仅运行单元测试：
+
+```bash
+npm run unit
+```
+
 如果只需运行 e2e 测试：
 
 ```bash


### PR DESCRIPTION
## 摘要
- 增加对 TOTP 与备份码的综合测试
- README 中补充了仅运行单元测试的说明

## 测试指南
在 `server` 目录执行：
```bash
npm install
npm run unit
```
上述命令会运行所有单元测试。由于环境限制，e2e 测试未执行。

------
https://chatgpt.com/codex/tasks/task_e_6842d251aae0832680593ff57eb9982b