### PR TITLE
添加 passkey 接口测试

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ npm run unit
 npm run e2e
 ```
 
+新增 `passkey.test.js` 用于覆盖通行密钥相关接口，运行 `npm test` 会一并执行。
+
 ## API 说明
 
 ### `POST /logout`

--- a/server/index.js
+++ b/server/index.js
@@ -377,10 +377,10 @@ app.post('/session', authenticateToken, async (req, res) => {
 app.post('/passkey/options', authenticateToken, async (req, res) => {
   try {
     const user = await getUserByUsername(req.user.username);
-    const options = generateRegistrationOptions({
+    const options = await generateRegistrationOptions({
       rpName: 'LetuslearnID',
       rpID: req.headers.host.split(':')[0],
-      userID: String(user.id),
+      userID: Buffer.from(String(user.id)),
       userName: user.username
     });
     challenges[user.username] = options.challenge;

--- a/server/test/passkey.test.js
+++ b/server/test/passkey.test.js
@@ -1,0 +1,70 @@
+process.env.DB_FILE = ':memory:';
+const request = require('supertest');
+const assert = require('assert');
+const { promisify } = require('util');
+const { app, initDb, db } = require('../index');
+
+const run = promisify(db.run.bind(db));
+const get = promisify(db.get.bind(db));
+
+before(async () => {
+  await initDb();
+});
+
+
+describe('Passkey endpoints', () => {
+  let token;
+
+  before(async () => {
+    await request(app)
+      .post('/register')
+      .send({ username: 'pkuser', password: 'secret' });
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'pkuser', password: 'secret' });
+    token = res.body.token;
+  });
+
+  it('provides registration options', async () => {
+    const res = await request(app)
+      .post('/passkey/options')
+      .set('Authorization', 'Bearer ' + token);
+    assert.strictEqual(res.status, 200);
+    assert.ok(res.body.challenge);
+  });
+
+  it('fails registration with invalid response', async () => {
+    const res = await request(app)
+      .post('/passkey/register')
+      .set('Authorization', 'Bearer ' + token)
+      .send({});
+    assert.strictEqual(res.status, 400);
+  });
+
+  it('removes existing passkey', async () => {
+    await run("UPDATE users SET credential_id='a', passkey_public='b' WHERE username='pkuser'");
+    const res = await request(app)
+      .post('/passkey/remove')
+      .set('Authorization', 'Bearer ' + token);
+    assert.strictEqual(res.status, 200);
+    const row = await get('SELECT credential_id FROM users WHERE username=?', 'pkuser');
+    assert.strictEqual(row.credential_id, null);
+  });
+
+  it('provides auth options and fails verification', async () => {
+    await run("UPDATE users SET credential_id='abc', passkey_public='bcd' WHERE username='pkuser'");
+    await request(app)
+      .post('/session')
+      .set('Authorization', 'Bearer ' + token)
+      .send({ fingerprint: 'fp1', days: 1 })
+      .expect(200);
+    const opt = await request(app)
+      .post('/passkey/auth-options')
+      .send({ fingerprint: 'fp1' });
+    assert.strictEqual(opt.status, 200);
+    const res = await request(app)
+      .post('/passkey/auth?fingerprint=fp1')
+      .send({ rawId: 'abc', response: {}, type: 'public-key' });
+    assert.strictEqual(res.status, 400);
+  });
+});


### PR DESCRIPTION
## 摘要
- 增加 `passkey.test.js` 覆盖通行密钥接口
- 修复注册选项生成逻辑以适配 `@simplewebauthn/server`
- 文档补充测试说明

## 测试说明
- `cd server && npm install`
- `npm test` 运行全部单元及 e2e 测试

------
https://chatgpt.com/codex/tasks/task_e_6842d7b7ccbc8326ba78f0dc065e3c8f