### PR TITLE
修复通行密钥启用流程

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,21 @@ npm run e2e
 服务器会删除该指纹的会话并将 token 标记为失效，成功时返回：
 
 ```json
+
 { "message": "logged out" }
+```
+
+### `GET /profile`
+
+返回当前登录用户的基础信息，包含通行密钥状态：
+
+```json
+{
+  "id": 1,
+  "username": "alice",
+  "totp": false,
+  "credential_id": null
+}
 ```
 
 ### `POST /passkey/register`

--- a/client/passkey/manage.html
+++ b/client/passkey/manage.html
@@ -24,11 +24,16 @@ function Manage(){
     fetch('/profile',{headers:{'Authorization':'Bearer '+token}})
       .then(r=>r.json()).then(d=>setEnabled(!!d.credential_id)).catch(()=>{});
   },[]);
+  const b64ToBuf=str=>Uint8Array.from(atob(str.replace(/-/g,'+').replace(/_/g,'/')),c=>c.charCodeAt(0));
   const enable=async()=>{
     const token=localStorage.getItem('token');
     const optRes=await fetch('/passkey/options',{method:'POST',headers:{'Authorization':'Bearer '+token}});
     const opts=await optRes.json();
-    opts.challenge=Uint8Array.from(atob(opts.challenge.replace(/-/g,'+').replace(/_/g,'/')),c=>c.charCodeAt(0));
+    opts.challenge=b64ToBuf(opts.challenge);
+    opts.user.id=b64ToBuf(opts.user.id);
+    if(opts.excludeCredentials){
+      opts.excludeCredentials=opts.excludeCredentials.map(c=>({...c,id:b64ToBuf(c.id)}));
+    }
     const cred=await navigator.credentials.create({publicKey:opts});
     const b=b=>btoa(String.fromCharCode(...new Uint8Array(b))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
     await fetch('/passkey/register',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+token},body:JSON.stringify({id:cred.id,rawId:b(cred.rawId),response:{attestationObject:b(cred.response.attestationObject),clientDataJSON:b(cred.response.clientDataJSON)},type:cred.type})});

--- a/server/index.js
+++ b/server/index.js
@@ -183,7 +183,12 @@ app.get('/profile', authenticateToken, async (req, res) => {
   try {
     const user = await getUserByUsername(req.user.username);
     if (!user) return res.status(404).json({ error: 'User not found' });
-    res.json({ id: user.id, username: user.username, totp: !!user.totp_secret });
+    res.json({
+      id: user.id,
+      username: user.username,
+      totp: !!user.totp_secret,
+      credential_id: user.credential_id
+    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Server error' });

--- a/server/test/passkey.test.js
+++ b/server/test/passkey.test.js
@@ -41,6 +41,15 @@ describe('Passkey endpoints', () => {
     assert.strictEqual(res.status, 400);
   });
 
+  it('returns credential_id in profile', async () => {
+    await run("UPDATE users SET credential_id='xyz' WHERE username='pkuser'");
+    const res = await request(app)
+      .get('/profile')
+      .set('Authorization', 'Bearer ' + token);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.credential_id, 'xyz');
+  });
+
   it('removes existing passkey', async () => {
     await run("UPDATE users SET credential_id='a', passkey_public='b' WHERE username='pkuser'");
     const res = await request(app)


### PR DESCRIPTION
## 摘要
- passkey 管理页面在 `enable()` 中补充 Base64 转换，保证 challenge、user.id 与排除列表正确解析
- `/profile` 接口返回 `credential_id` 字段
- 更新对应单元测试并增加新用例
- README 中补充 `/profile` API 说明

## 测试指南
1. 在 `server` 目录执行 `npm install`
2. 运行 `npm test` 查看全部测试应均通过



------
https://chatgpt.com/codex/tasks/task_e_6842dd8262d483269b0fe5dcaa532d59