### PR TITLE
修复Passkey注册/认证逻辑

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -437,6 +437,9 @@ app.post('/passkey/register', authenticateToken, async (req, res) => {
       expectedOrigin: `http://${req.headers.host}`,
       expectedRPID: req.headers.host.split(':')[0]
     });
+    if (!verification.verified || !verification.registrationInfo) {
+      throw new Error('Failed');
+    }
     const { credentialID, credentialPublicKey, counter } = verification.registrationInfo;
     await addPasskey(
       req.user.id,
@@ -496,6 +499,9 @@ app.post('/passkey/auth', async (req, res) => {
         counter: key.counter
       }
     });
+    if (!verification.verified || !verification.authenticationInfo) {
+      throw new Error('Failed');
+    }
     await updatePasskeyCounter(key.credential_id, verification.authenticationInfo.newCounter);
     const daysLeft = Math.max(1, Math.round((data.sess.expires_at - Date.now()) / 86400000));
     const token = generateToken(user, daysLeft);


### PR DESCRIPTION
## 摘要
- 修正 `/passkey/register` 和 `/passkey/auth` 在验证失败时的异常处理
- 新增对 `verifyRegistrationResponse` 与 `verifyAuthenticationResponse` 的返回值检查
- 确保验证失败时返回 400 而不会抛出 `toString` 相关错误

## 测试
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843c558d42c8326ba044f15cc14a77d