### PR TITLE
修复注册通行密钥验证

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ npm run e2e
 ```
 
 当字段缺失时会返回 400 状态码并记录错误信息，而不再输出完整的堆栈日志。
+若 WebAuthn 验证未通过也会返回相同的 400 状态码，不会再出现 "toString" 相关异常。
+由于注册选项采用 `userVerification: 'preferred'`，后端验证阶段已关闭强制 `requireUserVerification`，
+从而兼容未提供用户验证信息的设备。
 
 ## 未来工作
 

--- a/server/index.js
+++ b/server/index.js
@@ -435,9 +435,14 @@ app.post('/passkey/register', authenticateToken, async (req, res) => {
       response: req.body,
       expectedChallenge,
       expectedOrigin: `http://${req.headers.host}`,
-      expectedRPID: req.headers.host.split(':')[0]
+      expectedRPID: req.headers.host.split(':')[0],
+      requireUserVerification: false
     });
-    const { credentialID, credentialPublicKey, counter } = verification.registrationInfo;
+    if (!verification.verified || !verification.registrationInfo) {
+      throw new Error('Verification failed');
+    }
+    const { credentialID, credentialPublicKey, counter } =
+      verification.registrationInfo;
     await addPasskey(
       req.user.id,
       credentialID.toString('base64url'),
@@ -490,6 +495,7 @@ app.post('/passkey/auth', async (req, res) => {
       expectedChallenge: data.challenge,
       expectedOrigin: `http://${req.headers.host}`,
       expectedRPID: req.headers.host.split(':')[0],
+      requireUserVerification: false,
       authenticator: {
         credentialID: Buffer.from(key.credential_id, 'base64url'),
         credentialPublicKey: Buffer.from(key.public_key, 'base64'),


### PR DESCRIPTION
## 摘要
- 调整 `/passkey/register` 和 `/passkey/auth` 的验证逻辑，不再强制 `requireUserVerification`
- 文档补充说明兼容无用户验证的设备

## 测试
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843c900e5c4832694f3a8b2d14c95fa