### PR TITLE
修复Passkey验证接口

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -515,9 +515,9 @@ app.post('/passkey/auth', async (req, res) => {
       expectedOrigin: `http://${req.headers.host}`,
       expectedRPID: req.headers.host.split(':')[0],
       requireUserVerification: false,
-      authenticator: {
-        credentialID: Buffer.from(key.credential_id, 'base64url'),
-        credentialPublicKey: Buffer.from(key.public_key, 'base64'),
+      credential: {
+        id: key.credential_id,
+        publicKey: Buffer.from(key.public_key, 'base64'),
         counter: key.counter
       }
     });


### PR DESCRIPTION
## 摘要
- 升级 `verifyAuthenticationResponse` 调用参数，使用 `credential` 字段

## 测试
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843d342a8bc8326b389f253ea568305