### PR TITLE
新增Passkey验证取消按钮

### DIFF
--- a/client/passkey/verify.html
+++ b/client/passkey/verify.html
@@ -6,6 +6,7 @@
   <style>
     body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;align-items:center;justify-content:center;height:100vh;animation:fadeIn .3s ease;}
     .box{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);text-align:center;width:360px;}
+    .button{width:100%;padding:10px;background:#000;color:#fff;border:none;border-radius:20px;cursor:pointer;margin-top:10px;}
     @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
   </style>
 </head>
@@ -54,7 +55,11 @@ function VerifyPasskey(){
       }
     })();
   },[]);
-  return React.createElement('div',{className:'box'},'');
+  const cancel=()=>{window.location.href='../totp/verify.html';};
+  return React.createElement('div',{className:'box'},[
+    React.createElement('div',{key:0},'Processing...'),
+    React.createElement('button',{key:1,className:'button',onClick:cancel},'取消')
+  ]);
 }
 ReactDOM.render(React.createElement(VerifyPasskey),document.getElementById('root'));
 </script>


### PR DESCRIPTION
## 摘要
- 在 `client/passkey/verify.html` 中加入取消按钮，用户可以随时返回 TOTP 验证页
- 样式同步其它页面，新增 `.button` 样式

## 测试
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843d79e9e0c8326b7a9990c68b0e634