### PR TITLE
实现邮件验证及凭据找回

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,23 @@ LetuslearnID 是一个简单轻量的账户管理服务器，基于 [Express](ht
 
 登出时页面会调用 `/logout`，携带当前指纹并在请求头中附加 token。服务器删除该指纹的会话记录并使 token 失效，浏览器随后需执行 `localStorage.removeItem('token')` 并返回登录页。
 
+## SMTP 配置
+
+项目使用 `nodemailer` 发送验证码邮件，相关设置存放在 `server/emailconfig.json`。示例如下：
+
+```json
+{
+  "smtp": {
+    "host": "smtp.example.com",
+    "port": 465,
+    "secure": true,
+    "auth": { "user": "user@example.com", "pass": "password" }
+  },
+  "from": "noreply@example.com",
+  "subject": "LetuslearnID verification code",
+  "template": "Your verification code is {code}"
+}
+```
+
+按需修改 `smtp` 字段以匹配实际的邮件服务器地址和凭据，即可在注册、找回凭据及修改邮箱时收到验证码邮件。
+

--- a/client/index/password.html
+++ b/client/index/password.html
@@ -80,6 +80,7 @@
           React.createElement('i',{className:'fa-solid '+(showPw?'fa-eye-slash':'fa-eye'),onClick:()=>setShowPw(!showPw),style:{position:'absolute',right:'10px',top:'50%',transform:'translateY(-50%)',cursor:'pointer'}})
         ]),
         React.createElement('div',{key:4,className:'gray',onClick:verifyPasskey},'Use passkey?'),
+        React.createElement('div',{key:8,className:'gray',onClick:()=>window.location.href='../recover/index.html'},'Lost credentials?'),
         React.createElement('button',{key:5,className:'button',onClick:handleLogin},t.login),
         React.createElement('button',{key:6,className:'button',onClick:()=>window.location.href='../register/index.html'},t.sign_up_link),
         React.createElement('p',{key:7,className:'tip'},t.no_account)

--- a/client/recover/index.html
+++ b/client/recover/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Recover</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;align-items:center;justify-content:center;height:100vh;animation:fadeIn .3s ease;}
+    .box{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);text-align:center;width:360px;}
+    input{width:100%;padding:10px;margin:8px 0;border:1px solid #ccc;border-radius:4px;}
+    .button{width:100%;padding:10px;background:#000;color:#fff;border:none;border-radius:20px;cursor:pointer;margin-top:10px;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+  </style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+<script>
+function Recover(){
+  const [name,setName]=React.useState('');
+  const [locale,setLocale]=React.useState(localStorage.getItem('locale')||'en_us');
+  const [t,setT]=React.useState({});
+  React.useEffect(()=>{localStorage.setItem('locale',locale);fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title='Recover';}).catch(()=>setT({}));},[locale]);
+  const next=async()=>{
+    const r=await fetch('/recover',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username:name})});
+    const d=await r.json();
+    if(r.ok){sessionStorage.setItem('recovery_id',d.id);window.location.href='./verify.html';}else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+  };
+  return React.createElement('div',{className:'box'},[
+    React.createElement('select',{key:0,value:locale,onChange:e=>setLocale(e.target.value)},[
+      React.createElement('option',{value:'en_us',key:0},'English'),
+      React.createElement('option',{value:'zh_cn',key:1},'\u4e2d\u6587')
+    ]),
+    React.createElement('input',{key:1,placeholder:t.username||'Username',value:name,onChange:e=>setName(e.target.value)}),
+    React.createElement('button',{key:2,className:'button',onClick:next},t.continue)
+  ]);
+}
+ReactDOM.render(React.createElement(Recover),document.getElementById('root'));
+</script>
+</body>
+</html>

--- a/client/recover/verify.html
+++ b/client/recover/verify.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Recover Verify</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;align-items:center;justify-content:center;height:100vh;animation:fadeIn .3s ease;}
+    .box{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);text-align:center;width:360px;}
+    input{width:100%;padding:10px;margin:8px 0;border:1px solid #ccc;border-radius:4px;}
+    .button{width:100%;padding:10px;background:#000;color:#fff;border:none;border-radius:20px;cursor:pointer;margin-top:10px;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+  </style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+<script>
+function Verify(){
+  const [code,setCode]=React.useState('');
+  const [locale,setLocale]=React.useState(localStorage.getItem('locale')||'en_us');
+  const [t,setT]=React.useState({});
+  React.useEffect(()=>{localStorage.setItem('locale',locale);fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title='Recover';}).catch(()=>setT({}));},[locale]);
+  const submit=async()=>{
+    const id=sessionStorage.getItem('recovery_id');
+    const r=await fetch('/recover/verify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({id,code})});
+    const d=await r.json();
+    if(r.ok){localStorage.setItem('token',d.token);window.location.href='../manage/index.html';}else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+  };
+  return React.createElement('div',{className:'box'},[
+    React.createElement('select',{key:0,value:locale,onChange:e=>setLocale(e.target.value)},[
+      React.createElement('option',{value:'en_us',key:0},'English'),
+      React.createElement('option',{value:'zh_cn',key:1},'\u4e2d\u6587')
+    ]),
+    React.createElement('input',{key:1,placeholder:t.code||'Code',value:code,onChange:e=>setCode(e.target.value)}),
+    React.createElement('button',{key:2,className:'button',onClick:submit},t.continue)
+  ]);
+}
+ReactDOM.render(React.createElement(Verify),document.getElementById('root'));
+</script>
+</body>
+</html>

--- a/client/register/index.html
+++ b/client/register/index.html
@@ -23,6 +23,7 @@
   <script>
     function RegisterName() {
       const [username, setUsername] = React.useState(sessionStorage.getItem('reg_name') || '');
+      const [email, setEmail] = React.useState(sessionStorage.getItem('reg_email') || '');
       const [locale, setLocale] = React.useState(localStorage.getItem('locale') || 'en_us');
       const [t, setT] = React.useState({});
 
@@ -36,6 +37,7 @@
 
       const next = () => {
         sessionStorage.setItem('reg_name', username);
+        sessionStorage.setItem('reg_email', email);
         window.location.href = './password.html';
       };
 
@@ -47,6 +49,7 @@
           ),
           React.createElement('h1', null, t.register),
           React.createElement('input', { type:'text', placeholder:t.username, value:username, onChange:e=>setUsername(e.target.value) }),
+          React.createElement('input', { type:'email', placeholder:t.email || 'Email', value:email, onChange:e=>setEmail(e.target.value) }),
           React.createElement('button', { className:'button', onClick:next }, t.continue),
           React.createElement('p', { className:'tip' },
             React.createElement('a', { href:'../index/index.html' }, t.have_account)

--- a/client/register/password.html
+++ b/client/register/password.html
@@ -24,6 +24,7 @@
   <script>
     function Register() {
       const [username, setUsername] = React.useState(sessionStorage.getItem('reg_name') || '');
+      const [email] = React.useState(sessionStorage.getItem('reg_email') || '');
       const [password, setPassword] = React.useState('');
       const [confirm, setConfirm] = React.useState('');
       const [showPw, setShowPw] = React.useState(false);
@@ -52,11 +53,12 @@
           const res = await fetch('/register', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username, password })
+            body: JSON.stringify({ username, email, password })
           });
           const data = await res.json();
           if (res.ok) {
-            window.location.href = '../success/index.html?type=register';
+            sessionStorage.setItem('reg_id', data.id);
+            window.location.href = './verify.html';
           } else {
             window.location.href = `../failure/index.html?msg=${encodeURIComponent(data.error || 'Register failed')}`;
           }

--- a/client/register/verify.html
+++ b/client/register/verify.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Verify Email</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;align-items:center;justify-content:center;height:100vh;animation:fadeIn .3s ease;}
+    .box{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);text-align:center;width:360px;}
+    input{width:100%;padding:10px;margin:8px 0;border:1px solid #ccc;border-radius:4px;}
+    .button{width:100%;padding:10px;background:#000;color:#fff;border:none;border-radius:20px;cursor:pointer;margin-top:10px;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+  </style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+<script>
+function Verify(){
+  const [code,setCode]=React.useState('');
+  const [locale,setLocale]=React.useState(localStorage.getItem('locale')||'en_us');
+  const [t,setT]=React.useState({});
+  React.useEffect(()=>{
+    localStorage.setItem('locale',locale);
+    fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title=d.register||'Verify';}).catch(()=>setT({}));
+  },[locale]);
+  const submit=async()=>{
+    const id=sessionStorage.getItem('reg_id');
+    const res=await fetch('/register/verify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({id,code})});
+    const d=await res.json();
+    if(res.ok){window.location.href='../success/index.html?type=register';}
+    else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+  };
+  return React.createElement('div',{className:'box'},[
+    React.createElement('select',{key:0,value:locale,onChange:e=>setLocale(e.target.value)},[
+      React.createElement('option',{value:'en_us',key:0},'English'),
+      React.createElement('option',{value:'zh_cn',key:1},'\u4e2d\u6587')
+    ]),
+    React.createElement('input',{key:1,placeholder:t.code||'Code',value:code,onChange:e=>setCode(e.target.value)}),
+    React.createElement('button',{key:2,className:'button',onClick:submit},t.continue)
+  ]);
+}
+ReactDOM.render(React.createElement(Verify),document.getElementById('root'));
+</script>
+</body>
+</html>

--- a/client/settings/index.html
+++ b/client/settings/index.html
@@ -82,6 +82,37 @@
         window.location.href = '../success/index.html?msg=' + encodeURIComponent('Saved settings') + '&next=../settings/index.html';
       };
 
+      const handleChangeEmail = async () => {
+        const token = localStorage.getItem('token');
+        try {
+          const r = await fetch('/change-email', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+            body: JSON.stringify({ email: newEmail })
+          });
+          const d = await r.json();
+          if (!r.ok) {
+            window.location.href = '../failure/index.html?msg=' + encodeURIComponent(d.error || 'Failed');
+            return;
+          }
+          const code = prompt(t.email_code);
+          if (!code) return;
+          const vr = await fetch('/change-email/verify', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+            body: JSON.stringify({ id: d.id, code })
+          });
+          const vd = await vr.json();
+          if (vr.ok) {
+            window.location.href = '../success/index.html?msg=' + encodeURIComponent(t.success) + '&next=../settings/index.html';
+          } else {
+            window.location.href = '../failure/index.html?msg=' + encodeURIComponent(vd.error || 'Failed');
+          }
+        } catch (e) {
+          window.location.href = '../failure/index.html?msg=Email';
+        }
+      };
+
       const handleChangePassword = async () => {
         if (newPassword !== confirmPassword) {
           window.location.href = '../failure/index.html?msg=' + encodeURIComponent('Passwords do not match');
@@ -140,7 +171,7 @@
             ),
           React.createElement('h1', null, t.settings_title),
           React.createElement('input', { type:'email', placeholder:t.new_email, value:newEmail, onChange:e=>setNewEmail(e.target.value) }),
-          React.createElement('button', { className:'button', onClick:() => window.location.href = '../success/index.html?msg=' + encodeURIComponent(t.change_email) + '&next=../settings/index.html' },
+          React.createElement('button', { className:'button', onClick:handleChangeEmail },
             React.createElement('i', { className:'fa-solid fa-envelope icon-white' }), t.change_email
           ),
           React.createElement('div', { style:{position:'relative'} },

--- a/client/totp/verify.html
+++ b/client/totp/verify.html
@@ -41,6 +41,7 @@ function Verify(){
     React.createElement('input',{key:0,placeholder:'TOTP',value:code,onChange:e=>setCode(e.target.value)}),
     hasPasskey && React.createElement('div',{key:1,className:'gray',onClick:()=>window.location.href='../passkey/verify.html'},'Use passkey?'),
     React.createElement('div',{key:2,className:'gray',onClick:()=>setUseBackup(!useBackup)},'无法访问？使用备份代码。'),
+    React.createElement('div',{key:5,className:'gray',onClick:()=>window.location.href='../recover/index.html'},'丢失凭据？'),
     React.createElement('button',{key:3,className:'button',onClick:submit},'提交'),
     React.createElement('button',{key:4,className:'button',onClick:cancel},'取消')
   ]);

--- a/i18n/en_us.json
+++ b/i18n/en_us.json
@@ -1,6 +1,7 @@
 {
   "title": "Letuslearn.now Login",
   "username": "Username",
+  "email": "Email",
   "password": "Password",
   "login": "Login",
   "register": "Register",
@@ -10,6 +11,7 @@
   "change_password": "Change Password",
   "new_email": "New Email",
   "change_email": "Change Email",
+  "email_code": "Enter code from email",
   "twofactor": "Enable Two-Factor Auth",
   "passkeys": "Manage Passkeys",
   "backup_codes": "Generate Backup Codes",
@@ -33,5 +35,6 @@
   "bookmarks": "Bookmarks",
   "no_account": "Don't have account? Sign up!",
   "edit": "Edit",
-  "manage_totp": "Manage Two-Factor"
+  "manage_totp": "Manage Two-Factor",
+  "code": "Code"
 }

--- a/i18n/zh_cn.json
+++ b/i18n/zh_cn.json
@@ -1,6 +1,7 @@
 {
   "title": "Letuslearn.now 登录",
   "username": "用户名",
+  "email": "邮箱",
   "password": "密码",
   "login": "登录",
   "register": "注册",
@@ -10,6 +11,7 @@
   "change_password": "修改密码",
   "new_email": "新邮箱",
   "change_email": "修改邮箱",
+  "email_code": "请输入邮件中的验证码",
   "twofactor": "启用两步验证",
   "passkeys": "管理通行密钥",
   "backup_codes": "生成备用代码",
@@ -33,5 +35,6 @@
   "bookmarks": "书签",
   "no_account": "还没有账号？立即注册！",
   "edit": "修改",
-  "manage_totp": "管理两步验证"
+  "manage_totp": "管理两步验证",
+  "code": "验证码"
 }

--- a/server/email.js
+++ b/server/email.js
@@ -1,0 +1,16 @@
+const nodemailer = require('nodemailer');
+const config = require('./emailconfig.json');
+
+const transporter = nodemailer.createTransport(config.smtp);
+
+async function sendCode(to, code, subject = config.subject) {
+  const msg = {
+    from: config.from,
+    to,
+    subject,
+    text: config.template.replace('{code}', code)
+  };
+  await transporter.sendMail(msg);
+}
+
+module.exports = { sendCode };

--- a/server/emailconfig.json
+++ b/server/emailconfig.json
@@ -1,0 +1,14 @@
+{
+  "smtp": {
+    "host": "smtp.example.com",
+    "port": 465,
+    "secure": true,
+    "auth": {
+      "user": "user@example.com",
+      "pass": "password"
+    }
+  },
+  "from": "noreply@example.com",
+  "subject": "LetuslearnID verification code",
+  "template": "Your verification code is {code}"
+}

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ const initDb = () => {
   const query = `CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT UNIQUE,
+    email TEXT,
     password_hash TEXT,
     totp_secret TEXT,
     backup_codes TEXT
@@ -31,6 +32,15 @@ const initDb = () => {
     public_key TEXT,
     counter INTEGER DEFAULT 0
   )`;
+  const pendingQuery = `CREATE TABLE IF NOT EXISTS pending_codes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT,
+    email TEXT,
+    password_hash TEXT,
+    code TEXT,
+    action TEXT,
+    created_at INTEGER
+  )`;
   const sessionQuery = `CREATE TABLE IF NOT EXISTS sessions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER,
@@ -38,6 +48,7 @@ const initDb = () => {
     expires_at INTEGER
   )`;
   const alters = [
+    'ALTER TABLE users ADD COLUMN email TEXT',
     'ALTER TABLE users ADD COLUMN totp_secret TEXT',
     'ALTER TABLE users ADD COLUMN backup_codes TEXT'
   ];
@@ -45,6 +56,7 @@ const initDb = () => {
     promisify(db.run.bind(db))(query),
     promisify(db.run.bind(db))(passkeyQuery),
     promisify(db.run.bind(db))(sessionQuery),
+    promisify(db.run.bind(db))(pendingQuery),
     ...alters.map(a => promisify(db.run.bind(db))(a).catch(() => {}))
   ]);
 };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "bcryptjs": "^3.0.2",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.9.11",
         "otplib": "^12.0.1",
         "sqlite3": "^5.1.7"
       },
@@ -2366,6 +2367,15 @@
       },
       "engines": {
         "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nopt": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "otplib": "^12.0.1",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "mocha": "^10.2.0",

--- a/server/test/passkey.test.js
+++ b/server/test/passkey.test.js
@@ -16,9 +16,11 @@ describe('Passkey endpoints', () => {
   let token;
 
   before(async () => {
-    await request(app)
+    const reg = await request(app)
       .post('/register')
-      .send({ username: 'pkuser', password: 'secret' });
+      .send({ username: 'pkuser', email:'pk@ex.com', password: 'secret' });
+    const row = await get('SELECT id, code FROM pending_codes WHERE id=?', reg.body.id);
+    await request(app).post('/register/verify').send({ id: reg.body.id, code: row.code });
     const res = await request(app)
       .post('/login')
       .send({ username: 'pkuser', password: 'secret' });


### PR DESCRIPTION
## 摘要
- 新增 `server/email.js` 与 `emailconfig.json` 用于 SMTP 邮件发送
- 注册流程改为邮箱验证码确认
- 增加凭据找回及修改邮箱接口
- 设置页可修改邮箱
- 前端新增注册验证码及找回页面
- 文档补充 SMTP 配置说明
- 测试用例更新以适配新流程

## 测试
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843e8a941b8832693b9cf26e909b017