### PR TITLE
修复相对路径导致的跳转问题

### DIFF
--- a/client/email/verify.html
+++ b/client/email/verify.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="../utils/fingerprint.js"></script>
+<script src="/utils/fingerprint.js"></script>
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script>
@@ -21,16 +21,16 @@ function EmailVerify(){
   const [code,setCode]=React.useState('');
   const [locale,setLocale]=React.useState(localStorage.getItem('locale')||'en_us');
   const [t,setT]=React.useState({});
-  React.useEffect(()=>{localStorage.setItem('locale',locale);fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title='Email Verify';}).catch(()=>setT({}));},[locale]);
+  React.useEffect(()=>{localStorage.setItem('locale',locale);fetch(`/i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title='Email Verify';}).catch(()=>setT({}));},[locale]);
   const submit=async()=>{
     const token=localStorage.getItem('token');
     const id=sessionStorage.getItem('email_change_id');
     const r=await fetch('/change-email/verify',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+token},body:JSON.stringify({id,code})});
     const d=await r.json();
-    if(r.ok){window.location.href='../success/index.html?msg='+encodeURIComponent(t.success)+'&next=../settings/index.html';}
-    else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+    if(r.ok){window.location.href='/success/index.html?msg='+encodeURIComponent(t.success)+'&next=/settings/index.html';}
+    else{window.location.href='/failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
   };
-  const cancel=()=>{window.location.href='../settings/index.html';};
+  const cancel=()=>{window.location.href='/settings/index.html';};
   return React.createElement('div',{className:'box'},[
     React.createElement('select',{key:0,value:locale,onChange:e=>setLocale(e.target.value)},[
       React.createElement('option',{value:'en_us',key:0},'English'),

--- a/client/failure/index.html
+++ b/client/failure/index.html
@@ -25,7 +25,7 @@
 
       React.useEffect(() => {
         localStorage.setItem('locale', locale);
-        fetch(`../../i18n/${locale}.json`)
+        fetch(`/i18n/${locale}.json`)
           .then(res => res.json())
           .then(data => { setT(data); document.title = data.error_title || 'Failure'; })
           .catch(() => setT({}));

--- a/client/index/index.html
+++ b/client/index/index.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="../utils/fingerprint.js"></script>
+  <script src="/utils/fingerprint.js"></script>
   <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
   <script>
@@ -32,7 +32,7 @@
         fetch('/passkey/auth-options',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({fingerprint:fp})})
           .then(r=>r.ok?r.json():null)
           .then(async opts=>{
-            if(!opts||!opts.challenge)return fetch('/auto-login?fp='+encodeURIComponent(fp)).then(r=>r.ok?r.json():null).then(d=>{if(d&&d.token){localStorage.setItem('token',d.token);window.location.href='../manage/index.html';}});
+            if(!opts||!opts.challenge)return fetch('/auto-login?fp='+encodeURIComponent(fp)).then(r=>r.ok?r.json():null).then(d=>{if(d&&d.token){localStorage.setItem('token',d.token);window.location.href='/manage/index.html';}});
             const b64ToBuf=s=>Uint8Array.from(atob(s.replace(/-/g,'+').replace(/_/g,'/')),c=>c.charCodeAt(0));
             const bufToB64=b=>btoa(String.fromCharCode(...new Uint8Array(b))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
             opts.challenge=b64ToBuf(opts.challenge);
@@ -41,13 +41,13 @@
             const body={id:cred.id,rawId:bufToB64(cred.rawId),response:{authenticatorData:bufToB64(cred.response.authenticatorData),clientDataJSON:bufToB64(cred.response.clientDataJSON),signature:bufToB64(cred.response.signature),userHandle:cred.response.userHandle?bufToB64(cred.response.userHandle):null},type:cred.type};
             const vr=await fetch('/passkey/auth?fingerprint='+encodeURIComponent(fp),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
             const data=await vr.json();
-            if(vr.ok&&data.token){localStorage.setItem('token',data.token);window.location.href='../manage/index.html';}
+            if(vr.ok&&data.token){localStorage.setItem('token',data.token);window.location.href='/manage/index.html';}
           }).catch(()=>{});
       },[]);
 
       React.useEffect(()=>{
         localStorage.setItem('locale',locale);
-        fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title=d.title||'Login';}).catch(()=>setT({}));
+        fetch(`/i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title=d.title||'Login';}).catch(()=>setT({}));
       },[locale]);
 
         const next=()=>{sessionStorage.setItem('login_user',username);window.location.href='/index/password.html';};
@@ -60,7 +60,7 @@
         React.createElement('h1',{key:1},t.welcome_back||t.title),
         React.createElement('input',{key:2,type:'text',placeholder:t.username,value:username,onChange:e=>setUsername(e.target.value)}),
         React.createElement('button',{key:3,className:'button',onClick:next},t.login),
-        React.createElement('button',{key:4,className:'button',onClick:()=>window.location.href='../register/index.html'},t.sign_up_link),
+        React.createElement('button',{key:4,className:'button',onClick:()=>window.location.href='/register/index.html'},t.sign_up_link),
         React.createElement('p',{key:5,className:'tip'},t.no_account)
       ]);
     }

--- a/client/index/password.html
+++ b/client/index/password.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="../utils/fingerprint.js"></script>
+  <script src="/utils/fingerprint.js"></script>
   <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
   <script>
@@ -31,26 +31,26 @@
 
       React.useEffect(()=>{
         localStorage.setItem('locale',locale);
-        fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title=d.title||'Login';}).catch(()=>setT({}));
+        fetch(`/i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title=d.title||'Login';}).catch(()=>setT({}));
       },[locale]);
 
-      if(!username){ window.location.href='./index.html'; return null; }
+      if(!username){ window.location.href='/index/index.html'; return null; }
 
       const handleLogin=async()=>{
         try{
           const res=await fetch('/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username,password,fingerprint:getFingerprint()})});
           const data=await res.json();
-          if(res.ok&&data.token){ localStorage.setItem('token',data.token); window.location.href='../success/index.html?type=login'; }
-          else if(data.tfa){ sessionStorage.setItem('tfa',data.temp); window.location.href='../totp/verify.html'; }
-          else{ window.location.href=`../failure/index.html?msg=${encodeURIComponent(data.error||'Login failed')}`; }
-        }catch(e){ window.location.href='../failure/index.html?msg=Login%20error'; }
+          if(res.ok&&data.token){ localStorage.setItem('token',data.token); window.location.href='/success/index.html?type=login'; }
+          else if(data.tfa){ sessionStorage.setItem('tfa',data.temp); window.location.href='/totp/verify.html'; }
+          else{ window.location.href=`/failure/index.html?msg=${encodeURIComponent(data.error||'Login failed')}`; }
+        }catch(e){ window.location.href='/failure/index.html?msg=Login%20error'; }
       };
 
       const verifyPasskey=async()=>{
         try{
           const fp=getFingerprint();
           const opt=await fetch('/passkey/auth-options',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({fingerprint:fp,username})});
-          if(!opt.ok){window.location.href='../failure/index.html?msg=No%20passkey';return;}
+          if(!opt.ok){window.location.href='/failure/index.html?msg=No%20passkey';return;}
           const opts=await opt.json();
           const b64ToBuf=s=>Uint8Array.from(atob(s.replace(/-/g,'+').replace(/_/g,'/')),c=>c.charCodeAt(0));
           const bufToB64=b=>btoa(String.fromCharCode(...new Uint8Array(b))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
@@ -60,9 +60,9 @@
           const body={id:cred.id,rawId:bufToB64(cred.rawId),response:{authenticatorData:bufToB64(cred.response.authenticatorData),clientDataJSON:bufToB64(cred.response.clientDataJSON),signature:bufToB64(cred.response.signature),userHandle:cred.response.userHandle?bufToB64(cred.response.userHandle):null},type:cred.type};
           const vr=await fetch('/passkey/auth?fingerprint='+encodeURIComponent(fp),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
           const d=await vr.json();
-          if(vr.ok&&d.token){localStorage.setItem('token',d.token);window.location.href='../success/index.html?type=login';}
-          else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
-        }catch(e){window.location.href='../failure/index.html?msg=Passkey';}
+          if(vr.ok&&d.token){localStorage.setItem('token',d.token);window.location.href='/success/index.html?type=login';}
+          else{window.location.href='/failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+        }catch(e){window.location.href='/failure/index.html?msg=Passkey';}
       };
 
       return React.createElement('div',{className:'container'},[
@@ -73,16 +73,16 @@
         React.createElement('h1',{key:1},t.welcome_back||t.title),
         React.createElement('div',{key:2,style:{position:'relative'}},[
           React.createElement('input',{type:'text',disabled:true,style:{background:'#eee'},value:username}),
-          React.createElement('a',{href:'./index.html',style:{position:'absolute',right:'10px',top:'50%',transform:'translateY(-50%)',fontSize:'0.9em'}},t.edit||'Edit')
+          React.createElement('a',{href:'/index/index.html',style:{position:'absolute',right:'10px',top:'50%',transform:'translateY(-50%)',fontSize:'0.9em'}},t.edit||'Edit')
         ]),
         React.createElement('div',{key:3,style:{position:'relative'}},[
           React.createElement('input',{type:showPw?'text':'password',placeholder:t.password,value:password,onChange:e=>setPassword(e.target.value),onCopy:e=>e.preventDefault()}),
           React.createElement('i',{className:'fa-solid '+(showPw?'fa-eye-slash':'fa-eye'),onClick:()=>setShowPw(!showPw),style:{position:'absolute',right:'10px',top:'50%',transform:'translateY(-50%)',cursor:'pointer'}})
         ]),
         React.createElement('div',{key:4,className:'gray',onClick:verifyPasskey},'Use passkey?'),
-        React.createElement('div',{key:8,className:'gray',onClick:()=>window.location.href='../recover/index.html'},'Lost credentials?'),
+        React.createElement('div',{key:8,className:'gray',onClick:()=>window.location.href='/recover/index.html'},'Lost credentials?'),
         React.createElement('button',{key:5,className:'button',onClick:handleLogin},t.login),
-        React.createElement('button',{key:6,className:'button',onClick:()=>window.location.href='../register/index.html'},t.sign_up_link),
+        React.createElement('button',{key:6,className:'button',onClick:()=>window.location.href='/register/index.html'},t.sign_up_link),
         React.createElement('p',{key:7,className:'tip'},t.no_account)
       ]);
     }

--- a/client/manage/index.html
+++ b/client/manage/index.html
@@ -24,13 +24,13 @@
 
       React.useEffect(() => {
         const token = localStorage.getItem('token');
-        if (!token) { window.location.href = '../index/index.html'; return; }
-        fetch('/profile', { headers:{ 'Authorization':'Bearer '+token } }).then(r=>{ if(!r.ok) window.location.href='../index/index.html'; });
+        if (!token) { window.location.href = '/index/index.html'; return; }
+        fetch('/profile', { headers:{ 'Authorization':'Bearer '+token } }).then(r=>{ if(!r.ok) window.location.href='/index/index.html'; });
       }, []);
 
       React.useEffect(() => {
         localStorage.setItem('locale', locale);
-        fetch(`../../i18n/${locale}.json`)
+        fetch(`/i18n/${locale}.json`)
           .then(res => res.json())
           .then(data => { setT(data); document.title = data.manage_title || 'Manage'; })
           .catch(() => setT({}));
@@ -43,7 +43,7 @@
             React.createElement('option', { value:'zh_cn' }, '\u4e2d\u6587')
           ),
           React.createElement('h1', null, t.manage_title),
-          React.createElement('button', { className:'button', onClick:() => window.location.href='../settings/index.html' }, t.settings_title)
+          React.createElement('button', { className:'button', onClick:() => window.location.href='/settings/index.html' }, t.settings_title)
         )
       );
     }

--- a/client/passkey/confirm.html
+++ b/client/passkey/confirm.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="../utils/fingerprint.js"></script>
+<script src="/utils/fingerprint.js"></script>
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script>
@@ -30,14 +30,14 @@ function Confirm(){
     const cred=await navigator.credentials.create({publicKey:opts});
     const b=b=>bufToB64(b);
     await fetch('/passkey/register',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+token},body:JSON.stringify({id:cred.id,rawId:b(cred.rawId),response:{attestationObject:b(cred.response.attestationObject),clientDataJSON:b(cred.response.clientDataJSON)},type:cred.type})});
-    window.location.href='../success/index.html?msg=Success&next=manage.html';
+    window.location.href='/success/index.html?msg=Success&next=/passkey/manage.html';
   };
   const disable=async()=>{
     const token=localStorage.getItem('token');
     await fetch('/passkey/remove',{method:'POST',headers:{'Authorization':'Bearer '+token}});
-    window.location.href='../success/index.html?msg=Success&next=manage.html';
+    window.location.href='/success/index.html?msg=Success&next=/passkey/manage.html';
   };
-  const cancel=()=>{window.location.href='manage.html';};
+  const cancel=()=>{window.location.href='/passkey/manage.html';};
   return React.createElement('div',{className:'box'},[
     React.createElement('p',{key:0},action==='enable'?'确认开启通行密钥?':'确认关闭通行密钥?'),
     React.createElement('button',{key:1,className:'button',onClick:action==='enable'?enable:disable},'确认'),

--- a/client/passkey/manage.html
+++ b/client/passkey/manage.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="../utils/fingerprint.js"></script>
+<script src="/utils/fingerprint.js"></script>
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script>
@@ -24,13 +24,13 @@ function Manage(){
     fetch('/profile',{headers:{'Authorization':'Bearer '+token}})
       .then(r=>r.json()).then(d=>setEnabled(d.passkeys&&d.passkeys.length>0)).catch(()=>{});
   },[]);
-  const startEnable=()=>{sessionStorage.setItem('pkAction','enable');window.location.href='confirm.html';};
-  const startDisable=()=>{sessionStorage.setItem('pkAction','disable');window.location.href='confirm.html';};
+  const startEnable=()=>{sessionStorage.setItem('pkAction','enable');window.location.href='/passkey/confirm.html';};
+  const startDisable=()=>{sessionStorage.setItem('pkAction','disable');window.location.href='/passkey/confirm.html';};
   return React.createElement('div',{className:'box'},[
     enabled?
       React.createElement('button',{key:0,className:'button secondary',onClick:startDisable},'关闭'):
       React.createElement('button',{key:1,className:'button',onClick:startEnable},'开启'),
-    React.createElement('button',{key:2,className:'button',onClick:()=>window.location.href='../settings/index.html'},'返回')
+    React.createElement('button',{key:2,className:'button',onClick:()=>window.location.href='/settings/index.html'},'返回')
   ]);
 }
 ReactDOM.render(React.createElement(Manage),document.getElementById('root'));

--- a/client/passkey/verify.html
+++ b/client/passkey/verify.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <div id="root">Processing...</div>
-<script src="../utils/fingerprint.js"></script>
+<script src="/utils/fingerprint.js"></script>
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script>
@@ -25,7 +25,7 @@ function VerifyPasskey(){
       if(t)h['Authorization']='Bearer '+t;
       const optRes=await fetch('/passkey/auth-options',{method:'POST',headers:h,body:JSON.stringify({fingerprint:fp})});
       if(!optRes.ok){
-        window.location.href='../failure/index.html?msg=No%20passkey';
+        window.location.href='/failure/index.html?msg=No%20passkey';
         return;
       }
       const opts=await optRes.json();
@@ -49,13 +49,13 @@ function VerifyPasskey(){
       const data=await vr.json();
       if(vr.ok&&data.token){
         localStorage.setItem('token',data.token);
-        window.location.href='../manage/index.html';
+        window.location.href='/manage/index.html';
       }else{
-        window.location.href='../failure/index.html?msg='+encodeURIComponent(data.error||'Failed');
+        window.location.href='/failure/index.html?msg='+encodeURIComponent(data.error||'Failed');
       }
     })();
   },[]);
-  const cancel=()=>{window.location.href='../totp/verify.html';};
+  const cancel=()=>{window.location.href='/totp/verify.html';};
   return React.createElement('div',{className:'box'},[
     React.createElement('div',{key:0},'Processing...'),
     React.createElement('button',{key:1,className:'button',onClick:cancel},'取消')

--- a/client/recover/index.html
+++ b/client/recover/index.html
@@ -20,11 +20,11 @@ function Recover(){
   const [name,setName]=React.useState('');
   const [locale,setLocale]=React.useState(localStorage.getItem('locale')||'en_us');
   const [t,setT]=React.useState({});
-  React.useEffect(()=>{localStorage.setItem('locale',locale);fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title='Recover';}).catch(()=>setT({}));},[locale]);
+  React.useEffect(()=>{localStorage.setItem('locale',locale);fetch(`/i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title='Recover';}).catch(()=>setT({}));},[locale]);
   const next=async()=>{
     const r=await fetch('/recover',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username:name})});
     const d=await r.json();
-    if(r.ok){sessionStorage.setItem('recovery_id',d.id);window.location.href='./verify.html';}else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+    if(r.ok){sessionStorage.setItem('recovery_id',d.id);window.location.href='/recover/verify.html';}else{window.location.href='/failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
   };
   return React.createElement('div',{className:'box'},[
     React.createElement('select',{key:0,value:locale,onChange:e=>setLocale(e.target.value)},[

--- a/client/recover/verify.html
+++ b/client/recover/verify.html
@@ -20,12 +20,12 @@ function Verify(){
   const [code,setCode]=React.useState('');
   const [locale,setLocale]=React.useState(localStorage.getItem('locale')||'en_us');
   const [t,setT]=React.useState({});
-  React.useEffect(()=>{localStorage.setItem('locale',locale);fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title='Recover';}).catch(()=>setT({}));},[locale]);
+  React.useEffect(()=>{localStorage.setItem('locale',locale);fetch(`/i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title='Recover';}).catch(()=>setT({}));},[locale]);
   const submit=async()=>{
     const id=sessionStorage.getItem('recovery_id');
     const r=await fetch('/recover/verify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({id,code})});
     const d=await r.json();
-    if(r.ok){localStorage.setItem('token',d.token);window.location.href='../manage/index.html';}else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+    if(r.ok){localStorage.setItem('token',d.token);window.location.href='/manage/index.html';}else{window.location.href='/failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
   };
   return React.createElement('div',{className:'box'},[
     React.createElement('select',{key:0,value:locale,onChange:e=>setLocale(e.target.value)},[

--- a/client/register/index.html
+++ b/client/register/index.html
@@ -29,7 +29,7 @@
 
       React.useEffect(() => {
         localStorage.setItem('locale', locale);
-        fetch(`../../i18n/${locale}.json`)
+        fetch(`/i18n/${locale}.json`)
           .then(res => res.json())
           .then(data => { setT(data); document.title = data.register || 'Register'; })
           .catch(() => setT({}));
@@ -38,7 +38,7 @@
       const next = () => {
         sessionStorage.setItem('reg_name', username);
         sessionStorage.setItem('reg_email', email);
-        window.location.href = './password.html';
+        window.location.href = '/register/password.html';
       };
 
       return (
@@ -52,7 +52,7 @@
           React.createElement('input', { type:'email', placeholder:t.email || 'Email', value:email, onChange:e=>setEmail(e.target.value) }),
           React.createElement('button', { className:'button', onClick:next }, t.continue),
           React.createElement('p', { className:'tip' },
-            React.createElement('a', { href:'../index/index.html' }, t.have_account)
+            React.createElement('a', { href:'/index/index.html' }, t.have_account)
           )
         )
       );

--- a/client/register/password.html
+++ b/client/register/password.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="../utils/fingerprint.js"></script>
+  <script src="/utils/fingerprint.js"></script>
   <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
   <script>
@@ -34,19 +34,19 @@
 
       React.useEffect(() => {
         localStorage.setItem('locale', locale);
-        fetch(`../../i18n/${locale}.json`)
+        fetch(`/i18n/${locale}.json`)
           .then(res => res.json())
           .then(data => { setT(data); document.title = data.register || 'Register'; })
           .catch(() => setT({}));
       }, [locale]);
 
       if (!username) {
-        window.location.href = './index.html';
+        window.location.href = '/register/index.html';
       }
 
       const handleRegister = async () => {
         if (password !== confirm) {
-          window.location.href = '../failure/index.html?msg=' + encodeURIComponent('Passwords do not match');
+          window.location.href = '/failure/index.html?msg=' + encodeURIComponent('Passwords do not match');
           return;
         }
         try {
@@ -58,12 +58,12 @@
           const data = await res.json();
           if (res.ok) {
             sessionStorage.setItem('reg_id', data.id);
-            window.location.href = './verify.html';
+            window.location.href = '/register/verify.html';
           } else {
-            window.location.href = `../failure/index.html?msg=${encodeURIComponent(data.error || 'Register failed')}`;
+            window.location.href = `/failure/index.html?msg=${encodeURIComponent(data.error || 'Register failed')}`;
           }
         } catch (err) {
-          window.location.href = '../failure/index.html?msg=Register%20error';
+          window.location.href = '/failure/index.html?msg=Register%20error';
         }
       };
 
@@ -76,7 +76,7 @@
           React.createElement('h1', null, t.register),
           React.createElement('div', { style:{position:'relative'} },
             React.createElement('input', { type:'text', disabled:true, style:{background:'#eee'}, value:username }),
-            React.createElement('a', { href:'./index.html', style:{position:'absolute', right:'10px', top:'50%', transform:'translateY(-50%)', fontSize:'0.9em'} }, t.edit || 'Edit')
+            React.createElement('a', { href:'/register/index.html', style:{position:'absolute', right:'10px', top:'50%', transform:'translateY(-50%)', fontSize:'0.9em'} }, t.edit || 'Edit')
           ),
           React.createElement('div', { style:{position:'relative'} },
             React.createElement('input', { type:showPw?'text':'password', placeholder:t.password, value:password, onChange:e=>setPassword(e.target.value), onCopy:e=>e.preventDefault() }),
@@ -88,7 +88,7 @@
           ),
           React.createElement('button', { className:'button', onClick:handleRegister }, t.register),
           React.createElement('p', { className:'tip' },
-            React.createElement('a', { href:'../index/index.html' }, t.have_account)
+            React.createElement('a', { href:'/index/index.html' }, t.have_account)
           )
         )
       );

--- a/client/register/verify.html
+++ b/client/register/verify.html
@@ -22,14 +22,14 @@ function Verify(){
   const [t,setT]=React.useState({});
   React.useEffect(()=>{
     localStorage.setItem('locale',locale);
-    fetch(`../../i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title=d.register||'Verify';}).catch(()=>setT({}));
+    fetch(`/i18n/${locale}.json`).then(r=>r.json()).then(d=>{setT(d);document.title=d.register||'Verify';}).catch(()=>setT({}));
   },[locale]);
   const submit=async()=>{
     const id=sessionStorage.getItem('reg_id');
     const res=await fetch('/register/verify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({id,code})});
     const d=await res.json();
-    if(res.ok){window.location.href='../success/index.html?type=register';}
-    else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+    if(res.ok){window.location.href='/success/index.html?type=register';}
+    else{window.location.href='/failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
   };
   return React.createElement('div',{className:'box'},[
     React.createElement('select',{key:0,value:locale,onChange:e=>setLocale(e.target.value)},[

--- a/client/settings/index.html
+++ b/client/settings/index.html
@@ -26,7 +26,7 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="../utils/fingerprint.js"></script>
+  <script src="/utils/fingerprint.js"></script>
   <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
   <script>
@@ -63,7 +63,7 @@
 
       React.useEffect(() => {
         localStorage.setItem('locale', locale);
-        fetch(`../../i18n/${locale}.json`)
+        fetch(`/i18n/${locale}.json`)
           .then(res => res.json())
           .then(data => { setT(data); document.title = data.settings_title || 'Settings'; })
           .catch(() => setT({}));
@@ -79,7 +79,7 @@
           });
           
         } catch (e) { }
-        window.location.href = '../success/index.html?msg=' + encodeURIComponent('Saved settings') + '&next=../settings/index.html';
+        window.location.href = '/success/index.html?msg=' + encodeURIComponent('Saved settings') + '&next=/settings/index.html';
       };
 
       const handleChangeEmail = async () => {
@@ -92,19 +92,19 @@
           });
           const d = await r.json();
           if (!r.ok) {
-            window.location.href = '../failure/index.html?msg=' + encodeURIComponent(d.error || 'Failed');
+            window.location.href = '/failure/index.html?msg=' + encodeURIComponent(d.error || 'Failed');
             return;
           }
           sessionStorage.setItem('email_change_id', d.id);
-          window.location.href = '../email/verify.html';
+          window.location.href = '/email/verify.html';
         } catch (e) {
-          window.location.href = '../failure/index.html?msg=Email';
+          window.location.href = '/failure/index.html?msg=Email';
         }
       };
 
       const handleChangePassword = async () => {
         if (newPassword !== confirmPassword) {
-          window.location.href = '../failure/index.html?msg=' + encodeURIComponent('Passwords do not match');
+          window.location.href = '/failure/index.html?msg=' + encodeURIComponent('Passwords do not match');
           return;
         }
         const token = localStorage.getItem('token');
@@ -116,18 +116,18 @@
           });
           const data = await res.json();
           if (res.ok) {
-            window.location.href = '../success/index.html?type=login';
+            window.location.href = '/success/index.html?type=login';
           } else {
-            window.location.href = '../failure/index.html?msg=' + encodeURIComponent(data.error || 'Change failed');
+            window.location.href = '/failure/index.html?msg=' + encodeURIComponent(data.error || 'Change failed');
           }
         } catch (err) {
-          window.location.href = '../failure/index.html?msg=Change%20error';
+          window.location.href = '/failure/index.html?msg=Change%20error';
         }
       };
 
       const handleBackupCodes = () => {
         sessionStorage.setItem('totpAction','regenerate');
-        window.location.href = '../totp/confirm.html';
+        window.location.href = '/totp/confirm.html';
       };
 
       const handleLogout = async () => {
@@ -140,7 +140,7 @@
           });
         } catch (e) { }
         localStorage.removeItem('token');
-        window.location.href = '../index/index.html';
+        window.location.href = '/index/index.html';
       };
 
       return (
@@ -150,7 +150,7 @@
           ),
           menuOpen && React.createElement('div', { className:'menu' },
             React.createElement('a', { href:'#', onClick:handleLogout }, t.logout),
-            React.createElement('a', { href:'../manage/index.html' }, t.manage_page),
+            React.createElement('a', { href:'/manage/index.html' }, t.manage_page),
             bookmarks.map((b,i) => React.createElement('a', { key:i, href:b.url }, b.title))
           ),
           React.createElement('div', { className:'container' },
@@ -176,8 +176,8 @@
             React.createElement('i', { className:'fa-solid ' + (showConfirm?'fa-eye-slash':'fa-eye'), onClick:()=>setShowConfirm(!showConfirm), style:{position:'absolute', right:'10px', top:'50%', transform:'translateY(-50%)', cursor:'pointer'} })
           ),
           React.createElement('button', { className:'button', onClick:handleChangePassword }, t.change_password),
-          React.createElement('button', { className:'button', onClick:()=>window.location.href='../totp/manage.html' }, t.manage_totp),
-          React.createElement('button', { className:'button', onClick:()=>window.location.href='../passkey/manage.html' }, t.passkeys),
+          React.createElement('button', { className:'button', onClick:()=>window.location.href='/totp/manage.html' }, t.manage_totp),
+          React.createElement('button', { className:'button', onClick:()=>window.location.href='/passkey/manage.html' }, t.passkeys),
           React.createElement('input', { type:'number', min:2, max:13, value:sessionDays, onChange:e=>setSessionDays(e.target.value), placeholder:t.remember_days }),
           React.createElement('button', { className:'button secondary', onClick:handleBackupCodes },
             React.createElement('i', { className:'fa-solid fa-shield-halved icon-white' }), t.backup_codes

--- a/client/success/index.html
+++ b/client/success/index.html
@@ -68,7 +68,7 @@
 
       React.useEffect(() => {
         localStorage.setItem('locale', locale);
-        fetch(`../../i18n/${locale}.json`)
+        fetch(`/i18n/${locale}.json`)
           .then(res => res.json())
           .then(data => {
             setT(data);
@@ -88,7 +88,8 @@
         document.title = msg || t.success; // 这里也加 t.success 兜底
       }, [t]);
 
-      const next = nextParam || (type === 'register' ? '../index/index.html' : '../manage/index.html');
+      const abs = p => p && !p.startsWith('/') ? '/' + p : p;
+      const next = abs(nextParam) || (type === 'register' ? '/index/index.html' : '/manage/index.html');
 
       return (
         React.createElement('div', { className: 'box' },

--- a/client/totp/backup.html
+++ b/client/totp/backup.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="../utils/fingerprint.js"></script>
+<script src="/utils/fingerprint.js"></script>
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script>
@@ -28,7 +28,7 @@ function Codes(){
     sessionStorage.removeItem('totpCodes');
     sessionStorage.removeItem('totpCode');
     sessionStorage.removeItem('usePasskey');
-    window.location.href='../settings/index.html';
+    window.location.href='/settings/index.html';
   };
   const commitWithToken=async(t)=>{
     const res=await fetch('/totp/regenerate',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+t},body:JSON.stringify({code:sessionStorage.getItem('totpCode')||''})});
@@ -37,9 +37,9 @@ function Codes(){
       sessionStorage.removeItem('totpCodes');
       sessionStorage.removeItem('totpCode');
       sessionStorage.removeItem('usePasskey');
-      window.location.href='../success/index.html?msg=Success&next=../settings/index.html';
+      window.location.href='/success/index.html?msg=Success&next=/settings/index.html';
     }else{
-      window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');
+      window.location.href='/failure/index.html?msg='+encodeURIComponent(d.error||'Failed');
     }
   };
   const confirm=async()=>{
@@ -49,7 +49,7 @@ function Codes(){
         const fp=getFingerprint();
         const t=localStorage.getItem('token');
         const opt=await fetch('/passkey/auth-options',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+t},body:JSON.stringify({fingerprint:fp})});
-        if(!opt.ok){window.location.href='../failure/index.html?msg=No%20passkey';return;}
+        if(!opt.ok){window.location.href='/failure/index.html?msg=No%20passkey';return;}
         const opts=await opt.json();
         const b64ToBuf=s=>Uint8Array.from(atob(s.replace(/-/g,'+').replace(/_/g,'/')),c=>c.charCodeAt(0));
         const bufToB64=b=>btoa(String.fromCharCode(...new Uint8Array(b))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
@@ -59,8 +59,8 @@ function Codes(){
         const body={id:cred.id,rawId:bufToB64(cred.rawId),response:{authenticatorData:bufToB64(cred.response.authenticatorData),clientDataJSON:bufToB64(cred.response.clientDataJSON),signature:bufToB64(cred.response.signature),userHandle:cred.response.userHandle?bufToB64(cred.response.userHandle):null},type:cred.type};
         const vr=await fetch('/passkey/auth?fingerprint='+encodeURIComponent(fp),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
         const d=await vr.json();
-        if(vr.ok&&d.token){localStorage.setItem('token',d.token);commitWithToken(d.token);}else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
-      }catch(e){window.location.href='../failure/index.html?msg=Passkey';}
+        if(vr.ok&&d.token){localStorage.setItem('token',d.token);commitWithToken(d.token);}else{window.location.href='/failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+      }catch(e){window.location.href='/failure/index.html?msg=Passkey';}
     }else{
       commitWithToken(localStorage.getItem('token'));
     }

--- a/client/totp/confirm.html
+++ b/client/totp/confirm.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="../utils/fingerprint.js"></script>
+<script src="/utils/fingerprint.js"></script>
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script>
@@ -41,9 +41,9 @@ function Confirm(){
       if(res.ok){
         sessionStorage.setItem('totpCodes',JSON.stringify(data.codes));
         if(!usePk) sessionStorage.setItem('totpCode',code); else sessionStorage.setItem('usePasskey','1');
-        window.location.href='backup.html';
+        window.location.href='/totp/backup.html';
       }else{
-        window.location.href='../failure/index.html?msg='+encodeURIComponent(data.error||'Failed');
+        window.location.href='/failure/index.html?msg='+encodeURIComponent(data.error||'Failed');
       }
       return;
     }
@@ -53,12 +53,12 @@ function Confirm(){
       if(action==='update'){
         sessionStorage.setItem('totpSetup',JSON.stringify(data));
         sessionStorage.setItem('totpAction','verify');
-        window.location.href='setup.html';
+        window.location.href='/totp/setup.html';
       }else{
-        window.location.href='../success/index.html?msg=Success&next=../settings/index.html';
+        window.location.href='/success/index.html?msg=Success&next=/settings/index.html';
       }
     }else{
-      window.location.href='../failure/index.html?msg='+encodeURIComponent(data.error||'Failed');
+      window.location.href='/failure/index.html?msg='+encodeURIComponent(data.error||'Failed');
     }
   };
   const verifyPasskey=async()=>{
@@ -66,7 +66,7 @@ function Confirm(){
       const fp=getFingerprint();
       const t=localStorage.getItem('token');
       const opt=await fetch('/passkey/auth-options',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+t},body:JSON.stringify({fingerprint:fp})});
-      if(!opt.ok){window.location.href='../failure/index.html?msg=No%20passkey';return;}
+      if(!opt.ok){window.location.href='/failure/index.html?msg=No%20passkey';return;}
       const opts=await opt.json();
       const b64ToBuf=s=>Uint8Array.from(atob(s.replace(/-/g,'+').replace(/_/g,'/')),c=>c.charCodeAt(0));
       const bufToB64=b=>btoa(String.fromCharCode(...new Uint8Array(b))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
@@ -76,15 +76,15 @@ function Confirm(){
       const body={id:cred.id,rawId:bufToB64(cred.rawId),response:{authenticatorData:bufToB64(cred.response.authenticatorData),clientDataJSON:bufToB64(cred.response.clientDataJSON),signature:bufToB64(cred.response.signature),userHandle:cred.response.userHandle?bufToB64(cred.response.userHandle):null},type:cred.type};
       const vr=await fetch('/passkey/auth?fingerprint='+encodeURIComponent(fp),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
       const d=await vr.json();
-      if(vr.ok&&d.token){localStorage.setItem('token',d.token);submit(true);}else{window.location.href='../failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
-    }catch(e){window.location.href='../failure/index.html?msg=Passkey';}
+      if(vr.ok&&d.token){localStorage.setItem('token',d.token);submit(true);}else{window.location.href='/failure/index.html?msg='+encodeURIComponent(d.error||'Failed');}
+    }catch(e){window.location.href='/failure/index.html?msg=Passkey';}
   };
   const cancel=()=>{
     if(action==='verify'){
       fetch('/totp/cancel',{method:'POST',headers:{'Authorization':'Bearer '+localStorage.getItem('token')}})
-        .finally(()=>{window.location.href='../settings/index.html';});
+        .finally(()=>{window.location.href='/settings/index.html';});
     }else{
-      window.location.href='../settings/index.html';
+      window.location.href='/settings/index.html';
     }
   };
   return React.createElement('div',{className:'box'},[

--- a/client/totp/manage.html
+++ b/client/totp/manage.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="../utils/fingerprint.js"></script>
+<script src="/utils/fingerprint.js"></script>
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script>
@@ -30,17 +30,17 @@ function Manage(){
     const data=await r.json();
     sessionStorage.setItem('totpSetup',JSON.stringify(data));
     sessionStorage.setItem('totpAction','verify');
-    window.location.href='setup.html';
+    window.location.href='/totp/setup.html';
   };
-  const update=()=>{sessionStorage.setItem('totpAction','update');window.location.href='confirm.html';};
-  const disable=()=>{sessionStorage.setItem('totpAction','disable');window.location.href='confirm.html';};
+  const update=()=>{sessionStorage.setItem('totpAction','update');window.location.href='/totp/confirm.html';};
+  const disable=()=>{sessionStorage.setItem('totpAction','disable');window.location.href='/totp/confirm.html';};
   return React.createElement('div',{className:'box'},[
     enabled?[
       React.createElement('button',{key:0,className:'button',onClick:update},'更新'),
       React.createElement('button',{key:1,className:'button secondary',onClick:disable},'关闭')
     ]:
       React.createElement('button',{key:2,className:'button',onClick:startSetup},'开启'),
-    React.createElement('button',{key:3,className:'button',onClick:()=>window.location.href='../settings/index.html'},'返回')
+    React.createElement('button',{key:3,className:'button',onClick:()=>window.location.href='/settings/index.html'},'返回')
   ]);
 }
 ReactDOM.render(React.createElement(Manage),document.getElementById('root'));

--- a/client/totp/setup.html
+++ b/client/totp/setup.html
@@ -36,8 +36,8 @@ function Setup(){
     React.createElement('p',{key:3},'请使用双因子认证器扫描下方二维码\n如「Google Authenticator」「1Password」等'),
     React.createElement('ul',{key:4},data.codes.map((c,i)=>React.createElement('li',{key:i},c))),
     React.createElement('button',{key:5,className:'button',onClick:download},'下载备份代码'),
-    React.createElement('button',{key:6,className:'button',onClick:()=>{fetch('/totp/cancel',{method:'POST',headers:{'Authorization':'Bearer '+localStorage.getItem('token')}}).finally(()=>{window.location.href='../settings/index.html';});}},'取消'),
-    React.createElement('button',{key:7,className:'button',onClick:()=>{sessionStorage.setItem('totpAction','verify');window.location.href='confirm.html';}},'下一步')
+    React.createElement('button',{key:6,className:'button',onClick:()=>{fetch('/totp/cancel',{method:'POST',headers:{'Authorization':'Bearer '+localStorage.getItem('token')}}).finally(()=>{window.location.href='/settings/index.html';});}},'取消'),
+    React.createElement('button',{key:7,className:'button',onClick:()=>{sessionStorage.setItem('totpAction','verify');window.location.href='/totp/confirm.html';}},'下一步')
   ]);
 }
 ReactDOM.render(React.createElement(Setup),document.getElementById('root'));

--- a/client/totp/verify.html
+++ b/client/totp/verify.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="../utils/fingerprint.js"></script>
+<script src="/utils/fingerprint.js"></script>
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script>
@@ -34,14 +34,14 @@ function Verify(){
     const token=sessionStorage.getItem('tfa');
     const res=await fetch('/totp/verify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token,code})});
     const data=await res.json();
-    if(res.ok){localStorage.setItem('token',data.token);window.location.href='../manage/index.html';}else{window.location.href='../failure/index.html?msg='+encodeURIComponent(data.error||'Verify failed');}
+    if(res.ok){localStorage.setItem('token',data.token);window.location.href='/manage/index.html';}else{window.location.href='/failure/index.html?msg='+encodeURIComponent(data.error||'Verify failed');}
   };
-  const cancel=()=>{window.location.href='../index/index.html';};
+  const cancel=()=>{window.location.href='/index/index.html';};
   return React.createElement('div',{className:'box'},[
     React.createElement('input',{key:0,placeholder:'TOTP',value:code,onChange:e=>setCode(e.target.value)}),
-    hasPasskey && React.createElement('div',{key:1,className:'gray',onClick:()=>window.location.href='../passkey/verify.html'},'Use passkey?'),
+    hasPasskey && React.createElement('div',{key:1,className:'gray',onClick:()=>window.location.href='/passkey/verify.html'},'Use passkey?'),
     React.createElement('div',{key:2,className:'gray',onClick:()=>setUseBackup(!useBackup)},'无法访问？使用备份代码。'),
-    React.createElement('div',{key:5,className:'gray',onClick:()=>window.location.href='../recover/index.html'},'丢失凭据？'),
+    React.createElement('div',{key:5,className:'gray',onClick:()=>window.location.href='/recover/index.html'},'丢失凭据？'),
     React.createElement('button',{key:3,className:'button',onClick:submit},'提交'),
     React.createElement('button',{key:4,className:'button',onClick:cancel},'取消')
   ]);

--- a/docs/dev/ProjectBase.md
+++ b/docs/dev/ProjectBase.md
@@ -120,6 +120,10 @@ npm run e2e
 ```
 
 当字段缺失时会返回 400 状态码并记录错误信息，而不再输出完整的堆栈日志。若 WebAuthn 验证未通过也会返回相同的 400 状态码，不会再出现 "toString" 相关异常。由于注册选项采用 `userVerification: 'preferred'`，后端验证阶段已关闭强制 `requireUserVerification`，从而兼容未提供用户验证信息的设备。
+### 前端路径问题
+
+早期前端跳转大量使用相对路径，复用提示页时会出现如 `/success/index.html?next=manage.html` 导致跳转到 `/success/manage.html` 的情况。现已统一改为绝对路径，并在读取 `next` 参数时补全 `/` 前缀，避免目录混淆。
+
 
 ## 未来工作
 


### PR DESCRIPTION
## 摘要
- 页面跳转和资源加载全部改为绝对路径，避免在提示页复用时进入错误目录
- success 页新增 `abs` 函数，自动为 `next` 参数补全前导 `/`
- 更新开发文档，记录前端路径的处理方式

## 测试指南
1. 在 `server` 目录执行 `npm install`
2. 运行 `npm test`，确保全部测试通过


------
https://chatgpt.com/codex/tasks/task_e_6843f97c5840832692c71954eeb7ef8f