### PR TITLE
Add OIDC demo frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,14 @@ TEST_CODE=123654 TEST_EMAIL=user@example.com npx mocha testemailsmtp.js
 
 若邮件成功送达则表示配置正确。
 
+
+## OIDC 前端示例
+
+后端在 `server/oidc.ts` 提供了基于 oidc-provider 的认证服务，可单独在 `server` 目录启动：
+
+```bash
+node oidc.ts
+```
+
+启动后访问 `http://localhost:3000/oidc/index.html`，点击按钮即可跳转到 OIDC 授权页并在回调页显示令牌结果。默认示例客户端使用 `cloudreve` 账户，密钥来自 `CLOUDREVE_SECRET` 环境变量。
+

--- a/client/oidc/callback.html
+++ b/client/oidc/callback.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <title>OIDC Callback</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;justify-content:center;align-items:center;height:100vh;}
+    .container{width:360px;background:#fff;padding:30px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);}
+    pre{background:#eee;padding:10px;border-radius:4px;overflow:auto;}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>登录结果</h1>
+    <pre id="out">加载中...</pre>
+  </div>
+<script>
+(async()=>{
+  const params=new URLSearchParams(location.search);
+  const code=params.get('code');
+  const state=params.get('state');
+  const saved=sessionStorage.getItem('state');
+  if(state!==saved){document.getElementById('out').textContent='state mismatch';return;}
+  const verifier=sessionStorage.getItem('verifier');
+  const body=new URLSearchParams({
+    grant_type:'authorization_code',
+    code,
+    redirect_uri:location.origin+'/oidc/callback.html',
+    code_verifier:verifier,
+    client_id:'cloudreve'
+  });
+  const res=await fetch('http://localhost:4000/oidc/token',{
+    method:'POST',
+    headers:{'Content-Type':'application/x-www-form-urlencoded','Authorization':'Basic '+btoa('cloudreve:CHANGE_ME')},
+    body
+  });
+  const data=await res.json();
+  document.getElementById('out').textContent=JSON.stringify(data,null,2);
+})();
+</script>
+</body>
+</html>

--- a/client/oidc/index.html
+++ b/client/oidc/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <title>OIDC Demo</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:0;background:#f5f5f5;display:flex;justify-content:center;align-items:center;height:100vh;}
+    .container{width:360px;background:#fff;padding:30px;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.1);text-align:center;}
+    .button{width:100%;padding:10px;background:#000;color:#fff;border:none;border-radius:20px;cursor:pointer;margin-top:10px;}
+    .button:hover{background:#333;}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>OIDC 登录示例</h1>
+    <button id="login" class="button">使用 LetuslearnID 登录</button>
+  </div>
+<script>
+(async()=>{
+  const rand=v=>Array.from(crypto.getRandomValues(new Uint8Array(v))).map(b=>('0'+b.toString(16)).slice(-2)).join('');
+  const b64u=s=>btoa(String.fromCharCode(...new Uint8Array(s))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+  const sha256=async str=>{
+    const data=new TextEncoder().encode(str);
+    const hash=await crypto.subtle.digest('SHA-256',data);
+    return new Uint8Array(hash);
+  };
+  document.getElementById('login').onclick=async()=>{
+    const verifier=rand(32);
+    const challenge=b64u(await sha256(verifier));
+    const state=rand(16);
+    sessionStorage.setItem('verifier',verifier);
+    sessionStorage.setItem('state',state);
+    const params=new URLSearchParams({
+      client_id:'cloudreve',
+      response_type:'code',
+      scope:'openid email',
+      redirect_uri:location.origin+'/oidc/callback.html',
+      code_challenge:challenge,
+      code_challenge_method:'S256',
+      state
+    });
+    location.href='http://localhost:4000/oidc/auth?'+params.toString();
+  };
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `client/oidc` with demo login & callback pages
- document how to run the OIDC demo

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f931bd3483268d7a718da67ae2ce