### PR TITLE
Make OIDC config interactive

### DIFF
--- a/docs/dev/ProjectBase.md
+++ b/docs/dev/ProjectBase.md
@@ -25,6 +25,12 @@
 
 登录成功后服务器会根据这些信息自动向 OIDC 端点登录，并将得到的 SSO token 传递给前端页面，前端再隐式跳转完成单点登录。
 
+### Preview: 交互式 OIDC 配置
+
+首次运行时 `server/oidcconfig.js` 会在终端提示：`请输入 LetuslearnID 部署域名（不含https://和末尾的/）`。
+随后在不同设备随机生成 `client_id`、`client_secret` 与 `jwt_key`，生成结果会写入日志并保存到数据库。
+如需重新配置，可执行 `npm run resetoidc` 再次交互生成。
+
 ## 部署考虑
 
 - **Docker**：利用 Docker 打包 Node.js 服务、数据库以及其他依赖，实现一致的部署环境。

--- a/server/oidcconfig.js
+++ b/server/oidcconfig.js
@@ -1,5 +1,7 @@
 import { promisify } from 'util';
 import crypto from 'crypto';
+import readline from 'readline/promises';
+import { stdin as input, stdout as output } from 'process';
 
 async function initOidcConfig(db, verbose = false) {
   const run = promisify(db.run.bind(db));
@@ -17,14 +19,18 @@ async function initOidcConfig(db, verbose = false) {
   )`);
   const row = await get('SELECT * FROM oidcauth LIMIT 1');
   if (!row) {
+    const rl = readline.createInterface({ input, output });
+    const domain = (await rl.question('请输入 LetuslearnID 部署域名（不含https://和末尾的/）: ')).trim();
+    rl.close();
+
     const cfg = {
       client_id: crypto.randomUUID(),
       client_secret: crypto.randomBytes(16).toString('hex'),
       username_key: 'sub',
       org_name: 'Letuslearn',
       app_name: 'LetuslearnID',
-      endpoint: 'https://sso.example.com',
-      jwt_key: 'PUBLICKEY',
+      endpoint: `https://${domain}`,
+      jwt_key: crypto.randomBytes(32).toString('hex'),
       extra_scope: 'profile email'
     };
     console.log('OIDC 配置初次生成:', cfg);


### PR DESCRIPTION
## Summary
- make `oidcconfig.js` ask for the deployment domain on first run
- store generated secrets in DB
- document interactive config steps

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845552f08a08326bf7d4de3da0dcb56