### PR TITLE
修复 HTTPS 代理下通行密钥注册失败

### DIFF
--- a/docs/dev/ProjectBase.md
+++ b/docs/dev/ProjectBase.md
@@ -37,7 +37,7 @@
 - **HTTPS**：使用如 Let’s Encrypt 的 TLS 证书，保证通信安全。
 - **可扩展性**：API 设计采用模块化路由，便于未来新增服务。
 - **代码结构**：普通用户的登录、验证及凭据保存等接口已集中到 `server/users.js`，更易于维护。
-- **Nginx 示例配置**：仓库 `docs/sites-nginx.conf` 提供虚拟主机示例，可参考部署。
+- **Nginx 示例配置**：仓库 `docs/sites-nginx.conf` 提供虚拟主机示例，可参考部署；反向代理需传递 `X-Forwarded-Proto` 头以便 WebAuthn 正确识别 HTTPS。
 - **监控与日志**：使用 **Winston** 等日志工具及 **Prometheus** 之类的监控方案，跟踪系统状态。
 
 ## 后续步骤

--- a/docs/sites-nginx.conf
+++ b/docs/sites-nginx.conf
@@ -38,6 +38,7 @@ server {
         proxy_set_header Host            $host;
         proxy_set_header X-Real-IP       $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
         # 关键：徹底去掉 Connection 头，避免 HTTP/2 协议冲突
         proxy_set_header Connection      "";

--- a/server/users.js
+++ b/server/users.js
@@ -491,10 +491,11 @@ function setupUserRoutes(app, db) {
     try {
       const expectedChallenge = challenges[req.user.username];
       if (!expectedChallenge) return res.status(400).json({ error: 'No challenge' });
+      const proto = (req.headers['x-forwarded-proto'] || 'http').split(',')[0];
       const verification = await verifyRegistrationResponse({
         response: req.body,
         expectedChallenge,
-        expectedOrigin: `http://${req.headers.host}`,
+        expectedOrigin: `${proto}://${req.headers.host}`,
         expectedRPID: req.headers.host.split(':')[0],
         requireUserVerification: false
       });
@@ -575,10 +576,11 @@ function setupUserRoutes(app, db) {
       const uid = data.sess ? data.sess.user_id : data.uid;
       if (!key || key.user_id !== uid) return res.status(404).json({ error: 'Unknown credential' });
       const user = await promisify(db.get.bind(db))('SELECT * FROM users WHERE id = ?', uid);
+      const proto = (req.headers['x-forwarded-proto'] || 'http').split(',')[0];
       const verification = await verifyAuthenticationResponse({
         response: req.body,
         expectedChallenge: data.challenge,
-        expectedOrigin: `http://${req.headers.host}`,
+        expectedOrigin: `${proto}://${req.headers.host}`,
         expectedRPID: req.headers.host.split(':')[0],
         requireUserVerification: false,
         credential: {


### PR DESCRIPTION
## Summary
- 从 `X-Forwarded-Proto` 读取协议，确保在 HTTPS 代理场景下 WebAuthn 验证的 `expectedOrigin` 正确
- 更新 Nginx 示例，加入 `X-Forwarded-Proto` 头
- 文档说明反向代理需传递此头部

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d69f2ff28832693fa8df868b6d112