### PR TITLE
Fix OIDC feature config

### DIFF
--- a/docs/dev/ProjectBase.md
+++ b/docs/dev/ProjectBase.md
@@ -141,6 +141,7 @@ npm run e2e
 
 系统现已引入 oidc-provider，提供标准的 `/oidc/.well-known/openid-configuration`、`/oidc/authorization`、`/oidc/token` 等端点。
 客户端应按 OIDC 流程跳转到 `/oidc/authorization` 取得 `code`，随后在 `/oidc/token` 交换 `access_token`。
+为保证生产环境安全，服务器在初始化 OIDC Provider 时关闭了 `devInteractions` 开发界面，相关配置位于 `server/index.js`。
 
 ### 前端路径问题
 

--- a/server/index.js
+++ b/server/index.js
@@ -128,7 +128,7 @@ initDb()
     oidc = new Provider(cfg.endpoint, {
       clients,
       formats: { AccessToken: 'jwt' },
-      features: { devInteractions: false },
+      features: { devInteractions: { enabled: false } },
       findAccount: async (ctx, id) => ({ accountId: id, claims: () => ({ sub: id }) }),
       jwks: {
         keys: [{


### PR DESCRIPTION
## Summary
- disable oidc-provider devInteractions with new syntax
- update docs to mention the change

## Testing
- `node node_modules/mocha/bin/mocha --ignore test/e2e.test.js` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684e2a61722883268a6c45b9ec846d86