### PR TITLE
修复 OIDC 初始化失败

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -129,14 +129,7 @@ initDb()
       clients,
       formats: { AccessToken: 'jwt' },
       features: { devInteractions: { enabled: false } },
-      findAccount: async (ctx, id) => ({ accountId: id, claims: () => ({ sub: id }) }),
-      jwks: {
-        keys: [{
-          kty: 'oct',
-          k: Buffer.from(cfg.jwt_key, 'hex').toString('base64url'),
-          kid: 'signing-key-1'
-        }]
-      }
+      findAccount: async (ctx, id) => ({ accountId: id, claims: () => ({ sub: id }) })
     });
     app.use('/oidc', oidc.callback());
     if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {


### PR DESCRIPTION
## 摘要
- 移除 `oidc-provider` 的 `jwks` 配置，避免加载 `oct` 密钥导致启动失败

## 测试
- `npm test` *(失败: mocha 未安装)*


------
https://chatgpt.com/codex/tasks/task_e_684e2e4cb9148326a439c93bd018036b