### PR TITLE
Update OIDC docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ TEST_CODE=123654 TEST_EMAIL=user@example.com npx mocha testemailsmtp.js
 若邮件成功送达则表示配置正确。
 
 
-启动后访问 `http://localhost:3000/oidc/index.html`，点击按钮即可跳转到 OIDC 授权页并在回调页显示令牌结果。现已集成 oidc-provider，可通过 `/oidc/authorization` 与 `/oidc/token` 完成标准登录流程。
+启动后访问 `http://localhost:3000/oidc/index.html`，点击按钮即可跳转到 OIDC 授权页并在回调页显示令牌结果。现已集成 oidc-provider，可通过 `/oidc/auth` 与 `/oidc/token` 完成标准登录流程。
 服务启动时会自动生成用以签名的 RSA 密钥对，因此无需手动配置。
 
 

--- a/docs/dev/ProjectBase.md
+++ b/docs/dev/ProjectBase.md
@@ -140,8 +140,8 @@ OIDC 相关配置和登录流程也在 `oidc.test.js` 覆盖，无需单独操�
 
 ### OIDC 标准端点
 
-系统现已引入 oidc-provider，提供标准的 `/oidc/.well-known/openid-configuration`、`/oidc/authorization`、`/oidc/token` 等端点。
-客户端应按 OIDC 流程跳转到 `/oidc/authorization` 取得 `code`，随后在 `/oidc/token` 交换 `access_token`。
+系统现已引入 oidc-provider，提供标准的 `/oidc/.well-known/openid-configuration`、`/oidc/auth`、`/oidc/token` 等端点。
+客户端应按 OIDC 流程跳转到 `/oidc/auth` 取得 `code`，随后在 `/oidc/token` 交换 `access_token`。
 为保证生产环境安全，服务器在初始化 OIDC Provider 时关闭了 `devInteractions` 开发界面，相关配置位于 `server/index.js`。
 从当前版本开始，OIDC Provider 在启动时会自动生成 RSA 密钥对用于签名，无需再读取 `jwt_key` 字段。
 


### PR DESCRIPTION
## Summary
- fix README and docs to use `/oidc/auth`

## Testing
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_684e7c32974c83268863e389d27835dd