### PR TITLE
改进启动提示并记录OIDC配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ vim emailconfig.json # SMTP
 npm start
 ```
 
+首次运行将提示输入 LetuslearnID 部署域名，并在终端打印生成的 OIDC 配置。
+如需重新生成配置，可执行 `npm run resetoidc`。
+
 ## 测试
 
 运行单元和端到端测试：

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ export { initDb, db } from './lib/db.js';
 import { initOIDCProvider } from './provider.js';
 import userRoutes from './users.js';
 import adminRoutes from './admin.js';
+import initOidcConfig from './oidcconfig.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -38,6 +39,7 @@ app.use('/admin', async (req, res, next) => {
 
 export let oidc;
 export async function initOIDC() {
+  await initOidcConfig(db);
   const issuer = process.env.ISSUER || 'https://id.letuslearn.now';
   oidc = await initOIDCProvider(issuer);
   app.use(oidc.callback());


### PR DESCRIPTION
## 摘要
- 在 `initOIDC` 阶段调用 `initOidcConfig`，首次启动时会提示输入域名并打印 OIDC 配置
- 更新 `README.md` 说明首次启动会生成 OIDC 配置，并给出重置命令

## 测试
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e8bb5673883268d700cfdf5718350