### PR TITLE
Improve OIDC init logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ vim emailconfig.json # SMTP
 npm start
 ```
 
-首次运行将提示输入 LetuslearnID 部署域名，并在终端打印生成的 OIDC 配置。
+首次运行会要求输入 `请输入 LetuslearnID 部署域名（不含https://和末尾的/）:`，
+系统写入数据库后会立刻读取并以 `OIDC 配置初次生成:` 打印配置内容。
 如需重新生成配置，可执行 `npm run resetoidc`。
 
 ## 测试

--- a/server/oidcconfig.js
+++ b/server/oidcconfig.js
@@ -38,10 +38,11 @@ async function initOidcConfig(db, verbose = false) {
       jwt_key: crypto.randomBytes(32).toString('hex'),
       extra_scope: 'profile email'
     };
-    console.log('OIDC 配置初次生成:', cfg);
     await run('INSERT INTO oidcauth (client_id,client_secret,username_key,org_name,app_name,endpoint,jwt_key,extra_scope) VALUES (?,?,?,?,?,?,?,?)',
       Object.values(cfg));
-    return cfg;
+    const inserted = await get('SELECT client_id,client_secret,username_key,org_name,app_name,endpoint,jwt_key,extra_scope FROM oidcauth LIMIT 1');
+    console.log('OIDC 配置初次生成:', inserted);
+    return inserted;
   } else {
     if (verbose) console.log('OIDC 配置:', row);
     return row;


### PR DESCRIPTION
## Summary
- log generated OIDC config after reading from DB
- document new message in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e902c48dc8326bc4d6d33d139e15b