### PR TITLE
配置OIDC支持Nginx反向代理

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,22 @@ TEST_CODE=123654 TEST_EMAIL=user@example.com npx mocha testemailsmtp.js
 
 启动后访问 `http://localhost:3000/oidc/index.html`，点击按钮即可跳转到 OIDC 授权页并在回调页显示令牌结果。系统会从 `oidc_clients` 表读取配置，并使用 `jose` 动态生成 RSA 密钥对。所有标准端点 `/auth`、`/token` 等均已启用，授权阶段可选择通过通行密钥或 TOTP 完成验证。
 
+## Nginx 反向代理部署
+
+若在生产环境通过 Nginx 终端 TLS，可按以下步骤让 OIDC 正确识别 HTTPS：
+
+1. **显式设置 ISSUER**：
+
+   ```bash
+   export ISSUER=https://id.letuslearn.now
+   ```
+
+2. **启用 Provider 的 proxy**：在 `server/provider.js` 创建 Provider 时加入 `proxy: true`。
+
+3. **Express 信任代理**：在 `server/index.js` 中调用 `app.set('trust proxy', true)` 以读取 `X-Forwarded-Proto`。
+
+4. **Nginx 传递真实协议**：在示例配置 `docs/sites-nginx.conf` 的 `location /` 内加入 `proxy_set_header X-Forwarded-Proto https;`。
+
+仅在 HTTPS 环境下，AList 等客户端才能按标准 OIDC 流程完成登录。
+
 

--- a/docs/dev/ProjectBase.md
+++ b/docs/dev/ProjectBase.md
@@ -31,7 +31,7 @@
 - **HTTPS**：使用如 Let’s Encrypt 的 TLS 证书，保证通信安全。
 - **可扩展性**：API 设计采用模块化路由，便于未来新增服务。
 - **代码结构**：普通用户的登录、验证及凭据保存等接口已集中到 `server/users.js`，更易于维护。
-- **Nginx 示例配置**：仓库 `docs/sites-nginx.conf` 提供虚拟主机示例，可参考部署；反向代理需传递 `X-Forwarded-Proto` 头以便 WebAuthn 正确识别 HTTPS。
+- **Nginx 示例配置**：仓库 `docs/sites-nginx.conf` 提供虚拟主机示例，可参考部署；反向代理需传递 `X-Forwarded-Proto` 头以便 WebAuthn 正确识别 HTTPS。若由 Nginx 终端 TLS，需在环境变量中显式设置 `ISSUER=https://id.letuslearn.now`，并在代码中启用 `app.set('trust proxy', true)` 及 OIDC Provider 的 `proxy: true`。
 - **监控与日志**：使用 **Winston** 等日志工具及 **Prometheus** 之类的监控方案，跟踪系统状态。
 
 ## 后续步骤

--- a/docs/sites-nginx.conf
+++ b/docs/sites-nginx.conf
@@ -38,7 +38,7 @@ server {
         proxy_set_header Host            $host;
         proxy_set_header X-Real-IP       $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
 
         # 关键：徹底去掉 Connection 头，避免 HTTP/2 协议冲突
         proxy_set_header Connection      "";

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export const app = express();
+app.set('trust proxy', true);
 app.use(express.json());
 
 const clientDir = path.join(__dirname, '..', 'client');

--- a/server/provider.js
+++ b/server/provider.js
@@ -50,6 +50,7 @@ export async function initOIDCProvider(issuer) {
       IdToken: 3600,
       RefreshToken: 60 * 60 * 24 * 30,
     },
+    proxy: true,
   };
 
   return new Provider(issuer, configuration);


### PR DESCRIPTION
## Summary
- enable `trust proxy` in Express app
- set `proxy: true` when creating OIDC Provider
- document reverse proxy usage in README
- update design doc with ISSUER and proxy notes
- adjust Nginx example to send fixed `X-Forwarded-Proto`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ebcf0a3e883268a7f7f9822548c19